### PR TITLE
Fix macOS global config path to match ECA server

### DIFF
--- a/src/main/clojure/dev/eca/eca_intellij/editor_actions.clj
+++ b/src/main/clojure/dev/eca/eca_intellij/editor_actions.clj
@@ -28,12 +28,11 @@
      1. `ECA_CONFIG_PATH` env var (absolute path) — honored as-is.
      2. `$XDG_CONFIG_HOME/eca/config.json` when the var is set.
      3. Platform default:
-        - macOS  : `~/Library/Application Support/eca/config.json`
         - Windows: `%APPDATA%\\eca\\config.json` (falls back to
           `~/.config/eca/config.json` when APPDATA is absent — which
           realistically never happens, but the fallback matches the
           other clients verbatim).
-        - Other  : `~/.config/eca/config.json`
+        - Others (macOS, Linux): `~/.config/eca/config.json`
 
    Does not touch the filesystem. Creation is the caller's
    responsibility (see `ensure-global-config-exists!`)."
@@ -48,9 +47,6 @@
 
       (and xdg (pos? (count (clojure.string/trim xdg))))
       (io/file xdg "eca" "config.json")
-
-      (clojure.string/includes? os-name "mac")
-      (io/file home "Library" "Application Support" "eca" "config.json")
 
       (clojure.string/includes? os-name "win")
       (let [appdata (System/getenv "APPDATA")]


### PR DESCRIPTION
## Summary
- Remove the macOS-specific branch in `get-global-config-path` that resolved to `~/Library/Application Support/eca/config.json`
- The ECA server uses `~/.config/eca/config.json` on all platforms (including macOS), so the Settings → Global Config tab was pointing to the wrong file

## Context
Same fix applied across all three editor clients:
- eca-desktop: https://github.com/editor-code-assistant/eca-desktop/pull/7
- eca-vscode: https://github.com/editor-code-assistant/eca-vscode/pull/22
- eca-intellij: this PR

## Test plan
- [x] Verified the macOS `cond` branch is removed and falls through to `linux-default-config-path` (`~/.config/eca/config.json`)

🤖 Generated with [eca](https://eca.dev)