### PR TITLE
Add Clojure test suite for webview integration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,12 @@ on:
     branches:
       - main
 
+# Cancel queued/in-progress runs for the same ref when a new push lands,
+# so rapid-fire commits to a feature branch do not pile up identical CI.
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,5 +45,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      # processResources follows src/main/resources/webview/dist (a
+      # symlink into eca-webview/dist) even when only the test task is
+      # invoked, because the IntelliJ Gradle plugin wires `classes`
+      # into the test graph. On fresh checkouts the dist symlink target
+      # does not exist, so create an empty placeholder; the test suite
+      # does not consume any bundled webview asset.
+      - name: Stub webview dist
+        run: mkdir -p eca-webview/dist
+
       - name: Run tests
         run: bb test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,49 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # The webview Vite bundle is required for the plugin to build
+          # cleanly; tests themselves don't load it, but keeping the
+          # submodule checkout consistent with publish_plugin.yaml
+          # avoids divergent CI surprises.
+          submodules: recursive
+
+      - name: Prepare java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Babashka
+        uses: DeLaGuardo/setup-clojure@master
+        with:
+          bb: '1.12.196'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Run tests
+        run: bb test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Tests
 
-- `bb test` runs the full Clojure suite via `./gradlew test` → `clojureTest` (JavaExec). The IntelliJ Platform plugin retrofits the stock `Test` task with JBR + PathClassLoader, which breaks `clojure.lang.RT`; the JavaExec route bypasses that.
+- `bb test` runs the full Clojure suite via `./gradlew test` which delegates to the `clojureTest` JavaExec task. The IntelliJ Platform plugin retrofits the stock `Test` task with JBR + PathClassLoader, which breaks `clojure.lang.RT`; the JavaExec route bypasses that.
 - Clojure tests live under `src/test/clojure/dev/eca/eca_intellij/`. Filename suffix `_test.clj` is required for auto-discovery by the runner at `src/test/clojure/eca_intellij/test_runner.clj`.
 - Shared fixtures (`test_fixtures.clj`) provide `with-test-project`, `with-stub-bridge`, and helpers like `sent-to-webview` / `sent-to-server` / `stub-reply!` so deftests can drive `webview/handle` without a real JCEF browser or ECA server.
 - Every bugfix should land with a named regression test. Pin the commit hash in the docstring so future readers know why the case exists.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,8 @@
 - Always make sure there is no reflection warnings and that bb build-plugin works after all changes were done.
+
+## Tests
+
+- `bb test` runs the full Clojure suite via `./gradlew test` → `clojureTest` (JavaExec). The IntelliJ Platform plugin retrofits the stock `Test` task with JBR + PathClassLoader, which breaks `clojure.lang.RT`; the JavaExec route bypasses that.
+- Clojure tests live under `src/test/clojure/dev/eca/eca_intellij/`. Filename suffix `_test.clj` is required for auto-discovery by the runner at `src/test/clojure/eca_intellij/test_runner.clj`.
+- Shared fixtures (`test_fixtures.clj`) provide `with-test-project`, `with-stub-bridge`, and helpers like `sent-to-webview` / `sent-to-server` / `stub-reply!` so deftests can drive `webview/handle` without a real JCEF browser or ECA server.
+- Every bugfix should land with a named regression test. Pin the commit hash in the docstring so future readers know why the case exists.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -214,10 +214,18 @@ val clojureTest by tasks.registering(JavaExec::class) {
     group = "verification"
     dependsOn("compileTestClojure")
 
-    classpath = sourceSets.test.get().runtimeClasspath +
-                files("build/classes/kotlin/main") +
+    // Build the classpath from the compile outputs + dependency JARs
+    // ONLY, deliberately leaving out `processResources`. Otherwise
+    // Gradle pulls `:processResources` into the graph just to satisfy
+    // the resource portion of `runtimeClasspath`, which fails on hosts
+    // where the `src/main/resources/webview/dist` symlink dangles
+    // (it points into the `eca-webview` submodule's npm build output,
+    // which the test job has no reason to build).
+    classpath = sourceSets.main.get().output.classesDirs +
+                sourceSets.test.get().output.classesDirs +
                 files("build/clojure/main") +
-                files("build/clojure/test")
+                files("build/clojure/test") +
+                configurations.named("testRuntimeClasspath").get()
 
     mainClass.set("clojure.main")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,13 @@ dependencies {
     implementation ("org.clojure:core.async:1.5.648") {
         because("issue https://clojure.atlassian.net/browse/ASYNC-248")
     }
+
+    // JUnit 4 stays available for any Kotlin platform-level tests we add
+    // alongside the Clojure suite (BasePlatformTestCase is JUnit 4 friendly).
+    // Clojure tests do not need a JUnit Platform engine because the
+    // `clojureTest` JavaExec task invokes `clojure.main -m
+    // eca-intellij.test-runner` directly.
+    testImplementation ("junit:junit:4.13.2")
 }
 
 sourceSets {
@@ -172,4 +179,65 @@ clojure.builds.named("main") {
     checkAll()
     aotAll()
     reflection.set("fail")
+}
+
+clojure.builds.named("test") {
+    // Test compilation needs the main Clojure + Kotlin output on its
+    // classpath (so test ns can `require` production code), plus the test
+    // runtime classpath itself for the fixtures namespace.
+    classpath.from(sourceSets.test.get().runtimeClasspath
+                   + file("build/classes/kotlin/main")
+                   + file("build/clojure/main")
+                   + file("build/classes/kotlin/test"))
+    checkAll()
+    // No `aotAll()` — keeps test compilation fast and avoids leaking AOT
+    // classes into the test-runtime jar. Reflection warnings are surfaced
+    // but do not fail the build; the main build is the strict gate.
+    reflection.set("warn")
+}
+
+// Dedicated test task for the Clojure unit + integration suite.
+//
+// Why a separate JavaExec instead of customizing the standard `test`:
+// The `org.jetbrains.intellij` plugin retrofits every `Test` task with
+// JBR (JetBrains Runtime) as the JVM, the IntelliJ sandbox, and
+// `-Djava.system.class.loader=com.intellij.util.lang.PathClassLoader`.
+// PathClassLoader's URLConnections are not JarURLConnections, which
+// makes Clojure's `RT.load` throw a ClassCastException before any
+// deftest can run. JBR's dynamically linked binaries also fail to
+// launch on NixOS hosts. By running our suite via JavaExec — which the
+// IDE plugin does not touch — we keep the stock `test` task available
+// for any future BasePlatformTestCase suite while sidestepping every
+// IDE-test-runner assumption.
+val clojureTest by tasks.registering(JavaExec::class) {
+    description = "Runs the Clojure test suite via clojure.test."
+    group = "verification"
+    dependsOn("compileTestClojure")
+
+    classpath = sourceSets.test.get().runtimeClasspath +
+                files("build/classes/kotlin/main") +
+                files("build/clojure/main") +
+                files("build/clojure/test")
+
+    mainClass.set("clojure.main")
+
+    // -m invokes (-main) on the named namespace, which discovers every
+    // `*_test.clj` file under src/test/clojure and runs its deftests.
+    args("-m", "eca-intellij.test-runner")
+}
+
+// `bb test` is wired to `./gradlew test`. Hook clojureTest into the
+// existing alias so the bb task keeps working without user-visible
+// changes, and disable the IntelliJ-plugin-managed `test` body itself
+// (no BasePlatformTestCase suite yet; reactivate when one lands).
+tasks.named("test") {
+    dependsOn("clojureTest")
+    enabled = false
+}
+
+// checkTestClojure reads the same output dir that compileTestClojure writes
+// to (build/clojure/test); declare the ordering edge so Gradle's task graph
+// validator stops complaining about an implicit dependency.
+tasks.named("checkTestClojure") {
+    mustRunAfter("compileTestClojure")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -190,7 +190,7 @@ clojure.builds.named("test") {
                    + file("build/clojure/main")
                    + file("build/classes/kotlin/test"))
     checkAll()
-    // No `aotAll()` — keeps test compilation fast and avoids leaking AOT
+    // No `aotAll()` keeps test compilation fast and avoids leaking AOT
     // classes into the test-runtime jar. Reflection warnings are surfaced
     // but do not fail the build; the main build is the strict gate.
     reflection.set("warn")
@@ -205,8 +205,8 @@ clojure.builds.named("test") {
 // PathClassLoader's URLConnections are not JarURLConnections, which
 // makes Clojure's `RT.load` throw a ClassCastException before any
 // deftest can run. JBR's dynamically linked binaries also fail to
-// launch on NixOS hosts. By running our suite via JavaExec — which the
-// IDE plugin does not touch — we keep the stock `test` task available
+// launch on NixOS hosts. By running our suite via JavaExec, which the
+// IDE plugin does not touch, we keep the stock `test` task available
 // for any future BasePlatformTestCase suite while sidestepping every
 // IDE-test-runner assumption.
 val clojureTest by tasks.registering(JavaExec::class) {

--- a/src/main/clojure/dev/eca/eca_intellij/webview.clj
+++ b/src/main/clojure/dev/eca/eca_intellij/webview.clj
@@ -409,7 +409,7 @@
                     wrapper ^VirtualFileWrapper (.save dialog base-dir ^String default-name)]
                 (when wrapper
                   (spit (.getFile wrapper) (:content data) :encoding "UTF-8"))))})
-          (logger/warn "Unkown webview message type:" type)))))
+          (logger/warn "Unknown webview message type:" type)))))
   nil)
 
 (defmethod api/config-updated :default

--- a/src/main/clojure/dev/eca/eca_intellij/webview.clj
+++ b/src/main/clojure/dev/eca/eca_intellij/webview.clj
@@ -156,6 +156,15 @@
                                        :position {:start {:line (inc start-line) :character (inc start-char)}
                                                   :end {:line (inc end-line) :character (inc end-char)}}}}))))})))
 
+(defn ^:private current-selected-editor
+  "Extracted so tests can stub the FileEditorManager static call. Returns
+   the currently-focused editor in `project`, or nil when none. Wrapping
+   in `some->` defends against `FileEditorManager/getInstance` returning
+   nil in early-startup races and against the manager itself reporting no
+   selected editor."
+  [^Project project]
+  (some-> (FileEditorManager/getInstance project) .getSelectedTextEditor))
+
 (defn handle [msg ^Project project]
   (let [{:keys [type data]} (json/parse-string msg keyword)]
     (if (= "webview/ready" type)
@@ -170,7 +179,7 @@
                                       project)
         (handle-config-changed project (db/get-in project [:server-config]))
         ;; send current opened editor if any
-        (when-let [editor (.getSelectedTextEditor (FileEditorManager/getInstance project))]
+        (when-let [editor (current-selected-editor project)]
           (on-focus-changed editor nil))
         (db/assoc-in project [:on-focus-changed-fns :webview] #'on-focus-changed)
         ;; Hook the log-store into the webview. Every new entry is

--- a/src/test/clojure/dev/eca/eca_intellij/editor_actions_test.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/editor_actions_test.clj
@@ -1,0 +1,165 @@
+(ns dev.eca.eca-intellij.editor-actions-test
+  "Unit tests for the global-config JSONC strip/validate/write helpers.
+
+   The same logic ships in eca-vscode and eca-desktop; behavior drift
+   here will surprise users switching editors. The 1 MB write cap, the
+   trailing-comma + comment handling, and the atomic write pattern are
+   all explicit acceptance criteria of the issue (88fca15) that wired
+   the Settings → Global Config tab in the first place."
+  (:require
+   [cheshire.core :as json]
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is testing]]
+   [dev.eca.eca-intellij.editor-actions :as editor-actions])
+  (:import
+   [java.io File]))
+
+(set! *warn-on-reflection* true)
+
+;; ── Path resolution ────────────────────────────────────────────────
+
+(defmacro ^:private with-env [env-map & body]
+  `(let [old# (->> ~env-map keys
+                   (map (fn [k#] [k# (System/getenv k#)]))
+                   (into {}))]
+     ;; System/setenv is JDK-internal; we cannot manipulate process env
+     ;; from a test. Skip env-driven branches that require runtime
+     ;; mutation and only assert pure code paths.
+     ~@body))
+
+(deftest get-global-config-path-respects-xdg-via-classpath-call
+  (testing "Smoke: returns *some* File (we cannot mutate env from JVM)."
+    (is (instance? File (editor-actions/get-global-config-path)))))
+
+;; ── JSONC strip via valid-jsonc? + write round-trip ───────────────
+;;
+;; The strip helpers are `^:private`; rather than coupling to them,
+;; tests exercise the public `write-global-config` flow which calls
+;; strip → validate → write, then read back to confirm bytes landed.
+
+(defn ^:private tmp-config-target ^File []
+  (File/createTempFile "eca-config-test-" ".json"))
+
+(defmacro ^:private with-isolated-config
+  "Re-point `get-global-config-path` to a fresh tmp file for the body."
+  [config-path-sym & body]
+  `(let [~config-path-sym (tmp-config-target)]
+     (.delete ~config-path-sym)
+     (with-redefs [editor-actions/get-global-config-path (fn [] ~config-path-sym)]
+       (try
+         ~@body
+         (finally
+           (when (.exists ~config-path-sym) (.delete ~config-path-sym)))))))
+
+(deftest write-accepts-empty-content
+  (with-isolated-config target
+    (let [result (editor-actions/write-global-config {:contents ""})]
+      (is (:ok result))
+      (is (= "" (slurp target))))))
+
+(deftest write-accepts-trailing-commas
+  (testing "JSONC accepts trailing commas before }/]; strip removes them"
+    (with-isolated-config target
+      (let [src "{\n  \"a\": 1,\n  \"b\": [1, 2,],\n}"
+            result (editor-actions/write-global-config {:contents src})]
+        (is (:ok result))
+        (is (= src (slurp target))
+            "file content stays verbatim; only the validation pass strips")))))
+
+(deftest write-accepts-line-comments
+  (with-isolated-config target
+    (let [src "// top-level\n{\n  // inline\n  \"a\": 1\n}"
+          result (editor-actions/write-global-config {:contents src})]
+      (is (:ok result))
+      (is (= src (slurp target))))))
+
+(deftest write-accepts-block-comments
+  (with-isolated-config target
+    (let [src "/* multi\nline\ncomment */ { \"a\": 1 }"
+          result (editor-actions/write-global-config {:contents src})]
+      (is (:ok result)))))
+
+(deftest write-preserves-urls-with-double-slashes-inside-strings
+  (testing "A bare `//` inside a JSON string must NOT be treated as a
+            line comment — otherwise URLs in config values get
+            mangled. Regression target for the strip-state machine."
+    (with-isolated-config target
+      (let [src "{ \"webhook\": \"https://example.com/path\" }"
+            result (editor-actions/write-global-config {:contents src})]
+        (is (:ok result))
+        (is (= "https://example.com/path"
+               (get (json/parse-string (slurp target)) "webhook"))
+            "URL must round-trip intact through strip + write")))))
+
+(deftest write-preserves-escaped-quotes-in-strings
+  (with-isolated-config target
+    (let [src "{ \"msg\": \"he said \\\"hi\\\"\" }"
+          result (editor-actions/write-global-config {:contents src})]
+      (is (:ok result))
+      (is (= "he said \"hi\""
+             (get (json/parse-string (slurp target)) "msg"))))))
+
+(deftest write-rejects-invalid-jsonc
+  (with-isolated-config target
+    (let [result (editor-actions/write-global-config
+                  {:contents "{ this is not json"})]
+      (is (false? (:ok result)))
+      (is (re-find #"Invalid JSONC" (:error result))))))
+
+(deftest write-rejects-payload-larger-than-1mb
+  (testing "Regression target: a runaway webview payload must not wedge
+            the host. Bytes-based, not chars-based; multibyte chars
+            count by UTF-8 byte length."
+    (with-isolated-config target
+      (let [too-big (str "\"" (apply str (repeat (* 1024 1024) "a")) "\"")
+            result (editor-actions/write-global-config {:contents too-big})]
+        (is (false? (:ok result)))
+        (is (re-find #"too large" (:error result)))
+        (is (not (.exists target))
+            "file MUST NOT be created when validation fails")))))
+
+(deftest write-creates-parent-directory-if-missing
+  (let [dir (File/createTempFile "eca-cfg-dir-" "")
+        target (io/file dir "nested" "deeper" "config.json")]
+    (.delete dir)
+    (with-redefs [editor-actions/get-global-config-path (fn [] target)]
+      (try
+        (let [result (editor-actions/write-global-config {:contents "{}"})]
+          (is (:ok result))
+          (is (.exists target)))
+        (finally
+          (when (.exists target) (.delete target))
+          (loop [d (.getParentFile target)]
+            (when (and d (.exists d) (.isDirectory d))
+              (.delete d)
+              (recur (.getParentFile d)))))))))
+
+(deftest read-returns-empty-contents-when-file-missing
+  (with-isolated-config target
+    (let [result (editor-actions/read-global-config)]
+      (is (= "" (:contents result)))
+      (is (false? (:exists result)))
+      (is (= (.getAbsolutePath target) (:path result))))))
+
+(deftest read-returns-file-contents-when-present
+  (with-isolated-config target
+    (spit target "{ \"a\": 1 }")
+    (let [result (editor-actions/read-global-config)]
+      (is (= "{ \"a\": 1 }" (:contents result)))
+      (is (true? (:exists result)))
+      (is (= (.getAbsolutePath target) (:path result))))))
+
+(deftest ensure-exists-creates-seed-file
+  (with-isolated-config target
+    (is (not (.exists target)))
+    (let [f (editor-actions/ensure-global-config-exists!)]
+      (is (.exists f))
+      (is (= "{}\n" (slurp f))))))
+
+(deftest ensure-exists-is-idempotent
+  (with-isolated-config target
+    (spit target "{\"already\":true}")
+    (let [f (editor-actions/ensure-global-config-exists!)]
+      (is (.exists f))
+      (is (= "{\"already\":true}" (slurp f))
+          "existing content must NOT be overwritten by ensure"))))

--- a/src/test/clojure/dev/eca/eca_intellij/editor_actions_test.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/editor_actions_test.clj
@@ -5,7 +5,7 @@
    here will surprise users switching editors. The 1 MB write cap, the
    trailing-comma + comment handling, and the atomic write pattern are
    all explicit acceptance criteria of the issue (88fca15) that wired
-   the Settings → Global Config tab in the first place."
+   the Settings -> Global Config tab in the first place."
   (:require
    [cheshire.core :as json]
    [clojure.java.io :as io]
@@ -14,28 +14,12 @@
   (:import
    [java.io File]))
 
-(set! *warn-on-reflection* true)
-
-;; ── Path resolution ────────────────────────────────────────────────
-
-(defmacro ^:private with-env [env-map & body]
-  `(let [old# (->> ~env-map keys
-                   (map (fn [k#] [k# (System/getenv k#)]))
-                   (into {}))]
-     ;; System/setenv is JDK-internal; we cannot manipulate process env
-     ;; from a test. Skip env-driven branches that require runtime
-     ;; mutation and only assert pure code paths.
-     ~@body))
-
 (deftest get-global-config-path-respects-xdg-via-classpath-call
   (testing "Smoke: returns *some* File (we cannot mutate env from JVM)."
     (is (instance? File (editor-actions/get-global-config-path)))))
 
-;; ── JSONC strip via valid-jsonc? + write round-trip ───────────────
-;;
-;; The strip helpers are `^:private`; rather than coupling to them,
-;; tests exercise the public `write-global-config` flow which calls
-;; strip → validate → write, then read back to confirm bytes landed.
+;; Tests below exercise the public write/read flow rather than the
+;; private strip helpers directly.
 
 (defn ^:private tmp-config-target ^File []
   (File/createTempFile "eca-config-test-" ".json"))
@@ -81,7 +65,7 @@
 
 (deftest write-preserves-urls-with-double-slashes-inside-strings
   (testing "A bare `//` inside a JSON string must NOT be treated as a
-            line comment — otherwise URLs in config values get
+            line comment -- otherwise URLs in config values get
             mangled. Regression target for the strip-state machine."
     (with-isolated-config target
       (let [src "{ \"webhook\": \"https://example.com/path\" }"

--- a/src/test/clojure/dev/eca/eca_intellij/log_store_test.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/log_store_test.clj
@@ -1,0 +1,127 @@
+(ns dev.eca.eca-intellij.log-store-test
+  "Unit tests for the in-memory log ring buffer + subscriber fan-out
+   that backs the Settings → Logs webview tab. The cap (5000 entries),
+   subscriber replacement on the same key, and subscriber exception
+   isolation are all behaviors the webview relies on; a regression
+   here would silently lose log entries or stall live tail forever."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [dev.eca.eca-intellij.db :as db]
+   [dev.eca.eca-intellij.log-store :as log-store]
+   [dev.eca.eca-intellij.test-fixtures :as fixt]))
+
+(deftest infer-level-flags-error-keywords
+  (is (= :error (log-store/infer-level "Something ERROR happened")))
+  (is (= :error (log-store/infer-level "FATAL: oom")))
+  (is (= :error (log-store/infer-level "java.lang.RuntimeException: boom")))
+  (is (= :error (log-store/infer-level "Traceback (most recent call last):"))))
+
+(deftest infer-level-flags-non-zero-exit
+  (is (= :error (log-store/infer-level "process exited with code 1")))
+  (is (= :info (log-store/infer-level "process exited with code 0")))
+  (testing "leading 0 in a longer code is still non-zero (e.g. 02 == 2)"
+    (is (= :error (log-store/infer-level "exited with code 02")))))
+
+(deftest infer-level-flags-failed-to
+  (is (= :error (log-store/infer-level "Failed to start server")))
+  (is (= :error (log-store/infer-level "failed to download artifact")))
+  (testing "case-insensitive"
+    (is (= :error (log-store/infer-level "FaIlEd To open file")))))
+
+(deftest infer-level-defaults-to-info
+  (is (= :info (log-store/infer-level "starting up")))
+  (is (= :info (log-store/infer-level ""))))
+
+(deftest append-stores-entry-in-ring-buffer
+  (fixt/with-test-project [project]
+    (log-store/append! project {:source :server :text "hello"})
+    (let [snap (log-store/snapshot project)]
+      (is (= 1 (count snap)))
+      (is (= "hello" (-> snap first :text)))
+      (is (= :server (-> snap first :source)))
+      (is (= 1 (-> snap first :seq))))))
+
+(deftest append-assigns-monotonic-seq-ids
+  (fixt/with-test-project [project]
+    (log-store/append! project {:source :server :text "a"})
+    (log-store/append! project {:source :server :text "b"})
+    (log-store/append! project {:source :server :text "c"})
+    (is (= [1 2 3] (mapv :seq (log-store/snapshot project))))))
+
+(deftest append-defaults-level-via-infer
+  (fixt/with-test-project [project]
+    (log-store/append! project {:source :server :text "ERROR ohno"})
+    (log-store/append! project {:source :server :text "all good"})
+    (is (= [:error :info] (mapv :level (log-store/snapshot project))))))
+
+(deftest append-honors-explicit-level
+  (fixt/with-test-project [project]
+    (log-store/append! project {:source :server :text "ERROR ohno"
+                                :level :info})
+    (is (= :info (-> (log-store/snapshot project) first :level)))))
+
+(deftest ring-buffer-caps-at-5000-entries-oldest-first
+  (fixt/with-test-project [project]
+    (dotimes [i 5050]
+      (log-store/append! project {:source :server :text (str "entry-" i)}))
+    (let [snap (log-store/snapshot project)]
+      (is (= 5000 (count snap)) "buffer size must stay at the 5000-entry cap")
+      (is (= "entry-50" (:text (first snap))) "oldest preserved is entry-50 (first 50 evicted)")
+      (is (= "entry-5049" (:text (last snap))) "newest preserved is the most recent push"))))
+
+(deftest subscriber-receives-each-new-entry
+  (fixt/with-test-project [project]
+    (let [received (atom [])]
+      (log-store/subscribe! project :test #(swap! received conj %))
+      (log-store/append! project {:source :server :text "one"})
+      (log-store/append! project {:source :server :text "two"})
+      (is (= ["one" "two"] (mapv :text @received))))))
+
+(deftest subscribe-replaces-prior-listener-under-same-key
+  (testing "On webview/ready re-delivery (tool-window re-open) the
+            handler re-runs subscribe! with key :webview — we MUST NOT
+            end up with two listeners both firing on every entry."
+    (fixt/with-test-project [project]
+      (let [hits-a (atom 0)
+            hits-b (atom 0)]
+        (log-store/subscribe! project :webview (fn [_] (swap! hits-a inc)))
+        (log-store/subscribe! project :webview (fn [_] (swap! hits-b inc)))
+        (log-store/append! project {:source :server :text "x"})
+        (is (= 0 @hits-a) "first listener replaced; must not fire")
+        (is (= 1 @hits-b) "second listener is the live one")))))
+
+(deftest subscriber-exception-does-not-poison-siblings
+  (testing "If one subscriber throws, the entry must still be buffered
+            and every other subscriber must still receive it."
+    (fixt/with-test-project [project]
+      (let [sibling-hits (atom 0)]
+        (log-store/subscribe! project :throwy
+                              (fn [_] (throw (ex-info "boom" {}))))
+        (log-store/subscribe! project :sibling
+                              (fn [_] (swap! sibling-hits inc)))
+        (log-store/append! project {:source :server :text "still landed"})
+        (is (= 1 @sibling-hits)
+            "sibling subscriber MUST fire even when sibling-key throws")
+        (is (= 1 (count (log-store/snapshot project)))
+            "entry MUST land in buffer even when a subscriber throws")))))
+
+(deftest unsubscribe-stops-callbacks
+  (fixt/with-test-project [project]
+    (let [hits (atom 0)]
+      (log-store/subscribe! project :x (fn [_entry] (swap! hits inc)))
+      (log-store/append! project {:source :server :text "a"})
+      (log-store/unsubscribe! project :x)
+      (log-store/append! project {:source :server :text "b"})
+      (is (= 1 @hits)))))
+
+(deftest clear-wipes-ring-but-not-stderr-string
+  (testing "`logs/clear` from the webview drops the in-memory buffer but
+            leaves :server-stderr-string alone (the editor-buffer
+            surface backs bug reports and must persist)."
+    (fixt/with-test-project [project
+                             :initial-db {:server-stderr-string "preserved\n"}]
+      (log-store/append! project {:source :server :text "a"})
+      (log-store/append! project {:source :server :text "b"})
+      (log-store/clear! project)
+      (is (= [] (log-store/snapshot project)))
+      (is (= "preserved\n" (db/get-in project [:server-stderr-string]))))))

--- a/src/test/clojure/dev/eca/eca_intellij/log_store_test.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/log_store_test.clj
@@ -1,6 +1,6 @@
 (ns dev.eca.eca-intellij.log-store-test
   "Unit tests for the in-memory log ring buffer + subscriber fan-out
-   that backs the Settings → Logs webview tab. The cap (5000 entries),
+   that backs the Settings -> Logs webview tab. The cap (5000 entries),
    subscriber replacement on the same key, and subscriber exception
    isolation are all behaviors the webview relies on; a regression
    here would silently lose log entries or stall live tail forever."
@@ -79,7 +79,7 @@
 
 (deftest subscribe-replaces-prior-listener-under-same-key
   (testing "On webview/ready re-delivery (tool-window re-open) the
-            handler re-runs subscribe! with key :webview — we MUST NOT
+            handler re-runs subscribe! with key :webview -- we MUST NOT
             end up with two listeners both firing on every entry."
     (fixt/with-test-project [project]
       (let [hits-a (atom 0)

--- a/src/test/clojure/dev/eca/eca_intellij/server_lifecycle_test.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/server_lifecycle_test.clj
@@ -10,8 +10,6 @@
    [dev.eca.eca-intellij.server :as server]
    [dev.eca.eca-intellij.test-fixtures :as fixt]))
 
-;; ── broadcast-status! ─────────────────────────────────────────────
-
 (deftest broadcast-status-fans-out-to-every-registered-listener
   (testing "Each listener registered under :on-status-changed-fns must
             receive (project, status). :webview is the listener wired
@@ -34,50 +32,29 @@
   (fixt/with-test-project [project]
     (is (nil? (#'server/broadcast-status! project :stopped)))))
 
-(deftest broadcast-status-allows-throwing-listener-to-not-poison-siblings
-  (testing "Production uses `run!` which does NOT catch — but the
-            cursor-editor listener and on-status-changed listeners are
-            expected to be tame. Document the current contract: a
-            throwing listener will propagate. If we tighten this later
-            this test must be updated."
+(deftest broadcast-status-throwing-listener-propagates
+  (testing "Current contract: production uses `run!` which does NOT
+            catch. Listeners are expected to be tame (status-bar update,
+            webview send-msg). If we ever want isolation across
+            listeners, broadcast-status! needs a try/catch and this test
+            should flip to assert siblings still fire."
     (fixt/with-test-project [project]
-      (let [hits (atom 0)]
-        (db/assoc-in project [:on-status-changed-fns]
-                     {:throwy (fn [_ _] (throw (ex-info "boom" {})))
-                      :good (fn [_ _] (swap! hits inc))})
-        (try (#'server/broadcast-status! project :running) (catch Throwable _))
-        ;; Listeners iterate via map-vals; one of two orders is possible.
-        ;; In the current `run!` impl the throw stops iteration after
-        ;; whichever listener fired first — both 0 and 1 are valid hits
-        ;; values. Just assert that the broadcast itself does not loop.
-        (is (<= @hits 1))))))
-
-;; ── config/download-server-path ──────────────────────────────────
+      (db/assoc-in project [:on-status-changed-fns]
+                   {:throwy (fn [_ _] (throw (ex-info "boom" {})))})
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (#'server/broadcast-status! project :running))))))
 
 (deftest download-server-path-uses-exe-suffix-on-windows
   (testing "Regression b27d515: on Windows the auto-downloaded server
             must land as `eca.exe`; without the extension the
             existence-check would always miss and we would re-download
             on every IDE start."
-    (let [original (System/getProperty "os.name")]
-      (try
-        (System/setProperty "os.name" "Windows 11")
-        (let [f (config/download-server-path)]
-          (is (= "eca.exe" (.getName f))))
-        (finally
-          (System/setProperty "os.name" (or original "Linux")))))))
+    (with-redefs [config/windows? (constantly true)]
+      (is (= "eca.exe" (.getName (config/download-server-path)))))))
 
 (deftest download-server-path-uses-no-extension-on-other-os
-  (let [original (System/getProperty "os.name")]
-    (try
-      (System/setProperty "os.name" "Linux")
-      (is (= "eca" (.getName (config/download-server-path))))
-      (System/setProperty "os.name" "Mac OS X")
-      (is (= "eca" (.getName (config/download-server-path))))
-      (finally
-        (System/setProperty "os.name" (or original "Linux"))))))
-
-;; ── public status reader ─────────────────────────────────────────
+  (with-redefs [config/windows? (constantly false)]
+    (is (= "eca" (.getName (config/download-server-path))))))
 
 (deftest status-reads-current-db-status
   (fixt/with-test-project [project

--- a/src/test/clojure/dev/eca/eca_intellij/server_lifecycle_test.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/server_lifecycle_test.clj
@@ -1,0 +1,85 @@
+(ns dev.eca.eca-intellij.server-lifecycle-test
+  "Tests for server.clj's status broadcast + config.clj's OS-aware
+   download path. The Windows .exe suffix (regression b27d515) and the
+   listener-keys log line (added so blank-webview bug reports can be
+   correlated with whether :webview was reached) both live here."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [dev.eca.eca-intellij.config :as config]
+   [dev.eca.eca-intellij.db :as db]
+   [dev.eca.eca-intellij.server :as server]
+   [dev.eca.eca-intellij.test-fixtures :as fixt]))
+
+;; ── broadcast-status! ─────────────────────────────────────────────
+
+(deftest broadcast-status-fans-out-to-every-registered-listener
+  (testing "Each listener registered under :on-status-changed-fns must
+            receive (project, status). :webview is the listener wired
+            in tool_window.clj's onLoadingStateChange; missing it on
+            broadcast time is the exact symptom that motivated the
+            structured per-broadcast log line in server.clj."
+    (fixt/with-test-project [project]
+      (let [hits-webview (atom [])
+            hits-statusbar (atom [])]
+        (db/assoc-in project [:on-status-changed-fns]
+                     {:webview (fn [p s] (swap! hits-webview conj [p s]))
+                      :status-bar (fn [p s] (swap! hits-statusbar conj [p s]))})
+        (#'server/broadcast-status! project :running)
+        (is (= 1 (count @hits-webview)))
+        (is (= 1 (count @hits-statusbar)))
+        (is (= :running (-> @hits-webview first second)))
+        (is (= project (-> @hits-webview first first)))))))
+
+(deftest broadcast-status-with-no-listeners-does-not-throw
+  (fixt/with-test-project [project]
+    (is (nil? (#'server/broadcast-status! project :stopped)))))
+
+(deftest broadcast-status-allows-throwing-listener-to-not-poison-siblings
+  (testing "Production uses `run!` which does NOT catch — but the
+            cursor-editor listener and on-status-changed listeners are
+            expected to be tame. Document the current contract: a
+            throwing listener will propagate. If we tighten this later
+            this test must be updated."
+    (fixt/with-test-project [project]
+      (let [hits (atom 0)]
+        (db/assoc-in project [:on-status-changed-fns]
+                     {:throwy (fn [_ _] (throw (ex-info "boom" {})))
+                      :good (fn [_ _] (swap! hits inc))})
+        (try (#'server/broadcast-status! project :running) (catch Throwable _))
+        ;; Listeners iterate via map-vals; one of two orders is possible.
+        ;; In the current `run!` impl the throw stops iteration after
+        ;; whichever listener fired first — both 0 and 1 are valid hits
+        ;; values. Just assert that the broadcast itself does not loop.
+        (is (<= @hits 1))))))
+
+;; ── config/download-server-path ──────────────────────────────────
+
+(deftest download-server-path-uses-exe-suffix-on-windows
+  (testing "Regression b27d515: on Windows the auto-downloaded server
+            must land as `eca.exe`; without the extension the
+            existence-check would always miss and we would re-download
+            on every IDE start."
+    (let [original (System/getProperty "os.name")]
+      (try
+        (System/setProperty "os.name" "Windows 11")
+        (let [f (config/download-server-path)]
+          (is (= "eca.exe" (.getName f))))
+        (finally
+          (System/setProperty "os.name" (or original "Linux")))))))
+
+(deftest download-server-path-uses-no-extension-on-other-os
+  (let [original (System/getProperty "os.name")]
+    (try
+      (System/setProperty "os.name" "Linux")
+      (is (= "eca" (.getName (config/download-server-path))))
+      (System/setProperty "os.name" "Mac OS X")
+      (is (= "eca" (.getName (config/download-server-path))))
+      (finally
+        (System/setProperty "os.name" (or original "Linux"))))))
+
+;; ── public status reader ─────────────────────────────────────────
+
+(deftest status-reads-current-db-status
+  (fixt/with-test-project [project
+                           :initial-db {:status :starting}]
+    (is (= :starting (server/status project)))))

--- a/src/test/clojure/dev/eca/eca_intellij/shared_test.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/shared_test.clj
@@ -1,0 +1,85 @@
+(ns dev.eca.eca-intellij.shared-test
+  "Unit tests for the camelCase walker and throttle helper. Every
+   outbound webview message goes through `map->camel-cased-map`, so a
+   regression here would silently mis-key every message the React app
+   listens for."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [dev.eca.eca-intellij.shared :as shared]))
+
+(deftest map->camel-cased-map-converts-top-level-keyword-keys
+  (testing "csk returns keywords; cheshire later JSON-encodes those into
+            string keys, so the Clojure-level invariant is :kebab-case →
+            :camelCase keywords."
+    (is (= {:chatId 1 :fooBar 2}
+           (shared/map->camel-cased-map {:chat-id 1 :foo-bar 2})))))
+
+(deftest map->camel-cased-map-walks-into-nested-maps
+  (testing "Nested maps in values are also camel-cased"
+    (is (= {:outerKey {:innerKey 1}}
+           (shared/map->camel-cased-map {:outer-key {:inner-key 1}})))))
+
+(deftest map->camel-cased-map-walks-into-vectors-of-maps
+  (testing "Each map inside a vector gets its keys camelCased independently"
+    (is (= {:items [{:itemId 1} {:itemId 2}]}
+           (shared/map->camel-cased-map {:items [{:item-id 1} {:item-id 2}]})))))
+
+(deftest map->camel-cased-map-preserves-non-keyword-keys
+  (testing "Strings, numbers, and other non-keyword keys are untouched"
+    (is (= {"already" 1 42 2}
+           (shared/map->camel-cased-map {"already" 1 42 2})))))
+
+(deftest map->camel-cased-map-handles-already-camel-keys
+  (testing "Already-camel keyword keys round-trip without further mangling"
+    (is (= {:chatId 1}
+           (shared/map->camel-cased-map {:chatId 1})))))
+
+(deftest map->camel-cased-map-handles-empty-input
+  (is (= {} (shared/map->camel-cased-map {}))))
+
+(deftest map->camel-cased-map-leaves-primitives-alone
+  (testing "Non-map non-vector branches in postwalk return unchanged"
+    (is (= "scalar" (shared/map->camel-cased-map "scalar")))
+    (is (= 42 (shared/map->camel-cased-map 42)))
+    (is (nil? (shared/map->camel-cased-map nil)))))
+
+(deftest map->camel-cased-map-handles-realistic-logs-appended-payload
+  (testing "`logs/appended` (regression target: 88fca15) — :session-id must
+            land on the wire as sessionId or the React Logs tab cannot
+            correlate entries with their chat."
+    (let [appended {:type "logs/appended"
+                    :data {:ts 1700000000000
+                           :seq 42
+                           :session-id "sess-abc"
+                           :source :server
+                           :level :info
+                           :text "started"}}
+          out (shared/map->camel-cased-map appended)]
+      (is (= :sessionId (->> out :data keys (some #{:sessionId})))
+          "sessionId key must appear on the data map as :sessionId")
+      (is (= "sess-abc" (get-in out [:data :sessionId]))))))
+
+(deftest throttle-runs-an-invocation
+  (let [hits (atom [])
+        throttled (shared/throttle (fn [v] (swap! hits conj v)) 50)]
+    (throttled :only)
+    ;; Give the go-loop a beat to consume the put before we observe.
+    (Thread/sleep 30)
+    (is (= [:only] @hits))))
+
+(deftest throttle-rate-limits-bursts
+  (testing "Pumping a burst within the throttle window must NOT fan
+            out to N calls — `throttle` is the throttle behind the
+            server-logs editor update, where unbounded invocation would
+            wedge the EDT."
+    (let [hits (atom 0)
+          throttled (shared/throttle (fn [_] (swap! hits inc)) 200)]
+      (dotimes [_ 10] (throttled :tick))
+      (Thread/sleep 50)
+      (let [count-at-50 @hits]
+        ;; Inside the 200ms window we should see at most one hit land
+        ;; (the go-loop reads exactly once then sleeps). Two is the
+        ;; safe upper bound if the test JVM was paused mid-burst.
+        (is (<= count-at-50 2)
+            (str "throttle should bound burst hits within window; got "
+                 count-at-50))))))

--- a/src/test/clojure/dev/eca/eca_intellij/shared_test.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/shared_test.clj
@@ -9,7 +9,7 @@
 
 (deftest map->camel-cased-map-converts-top-level-keyword-keys
   (testing "csk returns keywords; cheshire later JSON-encodes those into
-            string keys, so the Clojure-level invariant is :kebab-case →
+            string keys, so the Clojure-level invariant is :kebab-case ->
             :camelCase keywords."
     (is (= {:chatId 1 :fooBar 2}
            (shared/map->camel-cased-map {:chat-id 1 :foo-bar 2})))))
@@ -44,7 +44,7 @@
     (is (nil? (shared/map->camel-cased-map nil)))))
 
 (deftest map->camel-cased-map-handles-realistic-logs-appended-payload
-  (testing "`logs/appended` (regression target: 88fca15) — :session-id must
+  (testing "`logs/appended` (regression target: 88fca15) -- :session-id must
             land on the wire as sessionId or the React Logs tab cannot
             correlate entries with their chat."
     (let [appended {:type "logs/appended"
@@ -69,7 +69,7 @@
 
 (deftest throttle-rate-limits-bursts
   (testing "Pumping a burst within the throttle window must NOT fan
-            out to N calls — `throttle` is the throttle behind the
+            out to N calls -- `throttle` is the throttle behind the
             server-logs editor update, where unbounded invocation would
             wedge the EDT."
     (let [hits (atom 0)

--- a/src/test/clojure/dev/eca/eca_intellij/test_fixtures.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/test_fixtures.clj
@@ -3,12 +3,12 @@
 
    Two main pieces tests reach for:
 
-     * `with-test-project` — registers a synthetic `Project` in the real
+     * `with-test-project` -- registers a synthetic `Project` in the real
        `db/db*` atom for the body's duration, then cleans up. Lets every
        db.clj reader/writer in production code run unmodified against a
        per-test scratch slot.
 
-     * `with-stub-bridge` — replaces the IO-touching seams in
+     * `with-stub-bridge` -- replaces the IO-touching seams in
        `webview.clj` (`send-msg!`, `api/connected-client`, `api/request!`,
        `api/notify!`, `app-manager/invoke-later!`, `read-action!`,
        `current-selected-editor`) with capture-and-stub fns. Tests then
@@ -24,10 +24,6 @@
    [dev.eca.eca-intellij.webview :as webview])
   (:import
    [com.intellij.openapi.project Project]))
-
-(set! *warn-on-reflection* true)
-
-;; ── Project stand-in ──────────────────────────────────────────────
 
 (defn test-project
   "Return a `Project` stand-in with just enough surface for the
@@ -84,8 +80,6 @@
          (finally
            (swap! db/db* update :projects dissoc base-path#))))))
 
-;; ── Bridge stubs ──────────────────────────────────────────────────
-
 (defrecord BridgeStub [sent-to-webview
                       sent-to-server
                       request-replies])
@@ -98,7 +92,7 @@
 (defn sent-to-webview
   "Every message `send-msg!` would have shipped to the React app, in
    order. Each entry is the raw Clojure map captured before the
-   camel-case + cheshire trip — use `msg->json` when a test wants to
+   camel-case + cheshire trip -- use `msg->json` when a test wants to
    assert on byte-for-byte JSON shape."
   [bridge]
   @(:sent-to-webview bridge))
@@ -134,26 +128,18 @@
   [bridge method value]
   (swap! (:request-replies bridge) assoc method value))
 
-(defn make-stub-promise
-  "Public so macro expansion at call sites in other namespaces can
-   resolve the symbol; not intended as a general-purpose helper."
-  [value]
-  (doto (promise) (deliver value)))
-
 (defmacro with-stub-bridge
-  "Run `body` with every IO seam in webview.clj redirected through
-   `bridge-sym`:
+  "Run `body` with every IO seam in webview.clj redirected through a
+   fresh bridge bound to `bridge-sym`:
 
-     - `webview/send-msg!`              → capture msg into bridge
-     - `webview/current-selected-editor`→ nil (no editor active)
-     - `api/connected-client`           → ::stub-client sentinel
-     - `api/request!`                   → record + deliver pre-staged
-                                          reply (defaults to {})
-     - `api/notify!`                    → record (no return)
-     - `app-manager/invoke-later!`      → run :invoke-fn synchronously
-     - `app-manager/read-action!`       → run :run-fn synchronously
-
-   The bridge is created if you do not supply one."
+     - `webview/send-msg!`              capture msg into bridge
+     - `webview/current-selected-editor` nil (no editor active)
+     - `api/connected-client`           ::stub-client sentinel
+     - `api/request!`                   record + deliver pre-staged
+                                        reply (defaults to {})
+     - `api/notify!`                    record (no return)
+     - `app-manager/invoke-later!`      run :invoke-fn synchronously
+     - `app-manager/read-action!`       run :run-fn synchronously"
   [bridge-sym & body]
   `(let [~bridge-sym (bridge-stub)]
      (with-redefs
@@ -170,7 +156,7 @@
                                v# (if (contains? replies# method#)
                                     (get replies# method#)
                                     {})]
-                           (make-stub-promise v#))))
+                           (doto (promise) (deliver v#)))))
         api/notify! (fn [_client# args#]
                       (let [method# (first args#)
                             body# (second args#)]
@@ -181,17 +167,15 @@
         app-manager/read-action! (fn [opts#] ((:run-fn opts#)))]
        ~@body)))
 
-;; ── Misc helpers ──────────────────────────────────────────────────
-
 (defn msg->json
   "Serialize a captured outbound message through the same path
-   send-msg! takes in production (kebab→camel keys, then cheshire).
+   send-msg! takes in production (kebab->camel keys, then cheshire).
    Useful when a test wants to assert on the literal JSON shape."
   [msg]
   (json/generate-string (shared/map->camel-cased-map msg)))
 
 (defn to-json-payload
-  "Webview → host messages arrive as JSON strings. Build one from a
+  "Webview -> host messages arrive as JSON strings. Build one from a
    Clojure map so tests can drive `webview/handle` with realistic input."
   [m]
   (json/generate-string m))

--- a/src/test/clojure/dev/eca/eca_intellij/test_fixtures.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/test_fixtures.clj
@@ -1,0 +1,197 @@
+(ns dev.eca.eca-intellij.test-fixtures
+  "Shared scaffolding for the eca-intellij test suite.
+
+   Two main pieces tests reach for:
+
+     * `with-test-project` — registers a synthetic `Project` in the real
+       `db/db*` atom for the body's duration, then cleans up. Lets every
+       db.clj reader/writer in production code run unmodified against a
+       per-test scratch slot.
+
+     * `with-stub-bridge` — replaces the IO-touching seams in
+       `webview.clj` (`send-msg!`, `api/connected-client`, `api/request!`,
+       `api/notify!`, `app-manager/invoke-later!`, `read-action!`,
+       `current-selected-editor`) with capture-and-stub fns. Tests then
+       assert on captured messages with `sent-to-webview` /
+       `sent-to-server` rather than having to wire up real JCEF or a live
+       ECA process."
+  (:require
+   [cheshire.core :as json]
+   [com.github.ericdallo.clj4intellij.app-manager :as app-manager]
+   [dev.eca.eca-intellij.api :as api]
+   [dev.eca.eca-intellij.db :as db]
+   [dev.eca.eca-intellij.shared :as shared]
+   [dev.eca.eca-intellij.webview :as webview])
+  (:import
+   [com.intellij.openapi.project Project]))
+
+(set! *warn-on-reflection* true)
+
+;; ── Project stand-in ──────────────────────────────────────────────
+
+(defn test-project
+  "Return a `Project` stand-in with just enough surface for the
+   production code under test (`getName`, `getBasePath`). Methods we do
+   not list throw `AbstractMethodError` if invoked, which surfaces
+   test/prod drift loudly instead of silently producing nil."
+  (^Project []
+   (test-project {}))
+  (^Project [{:keys [name base-path]
+              :or {name "test-project"
+                   base-path (str "/tmp/eca-test-" (System/nanoTime) "-" (rand-int 100000))}}]
+   (reify Project
+     (getName [_] name)
+     (getBasePath [_] base-path))))
+
+(defn empty-project-state
+  "The initial per-project map that the production code expects to find
+   in `db/db*`. Mirrors `db/empty-project` but is duplicated here so
+   tests stay decoupled from db.clj's private vars."
+  [project]
+  {:project project
+   :status :running
+   :downloaded-server-path nil
+   :client nil
+   :server-process nil
+   :session {:mcp-servers {}}
+   :server-config {}
+   :on-status-changed-fns {}
+   :on-focus-changed-fns {}
+   :on-settings-changed-fns {}
+   :on-stderr-log-updated-fns {}
+   :server-stderr-string ""
+   :settings {}
+   :log-entries []
+   :log-next-seq 1
+   :log-subscribers {}})
+
+(defmacro with-test-project
+  "Bind `project-sym` to a fresh test Project registered in `db/db*`.
+   Optional :initial-db map is merged on top of the default empty state
+   so individual tests can pre-seed status, settings, etc.
+
+   Removes the project from `db/db*` on exit so siblings stay isolated."
+  [bindings & body]
+  (let [project-sym (first bindings)
+        opts (apply hash-map (rest bindings))]
+    `(let [~project-sym (test-project {})
+           base-path# (.getBasePath ~project-sym)]
+       (swap! db/db* assoc-in [:projects base-path#]
+              (merge (empty-project-state ~project-sym)
+                     ~(:initial-db opts)))
+       (try
+         ~@body
+         (finally
+           (swap! db/db* update :projects dissoc base-path#))))))
+
+;; ── Bridge stubs ──────────────────────────────────────────────────
+
+(defrecord BridgeStub [sent-to-webview
+                      sent-to-server
+                      request-replies])
+
+(defn bridge-stub []
+  (->BridgeStub (atom [])
+                (atom [])
+                (atom {})))
+
+(defn sent-to-webview
+  "Every message `send-msg!` would have shipped to the React app, in
+   order. Each entry is the raw Clojure map captured before the
+   camel-case + cheshire trip — use `msg->json` when a test wants to
+   assert on byte-for-byte JSON shape."
+  [bridge]
+  @(:sent-to-webview bridge))
+
+(defn last-to-webview-of-type
+  "Most recent outbound whose `:type` is `type`, or nil. Useful when an
+   inbound triggers multiple unrelated emissions and you only care
+   about one."
+  [bridge type]
+  (->> @(:sent-to-webview bridge) (filter #(= type (:type %))) last))
+
+(defn webview-of-type
+  "Every outbound whose `:type` is `type`, in order."
+  [bridge type]
+  (->> @(:sent-to-webview bridge) (filterv #(= type (:type %)))))
+
+(defn sent-to-server
+  "Vector of `[kind method body]` tuples for everything the production
+   code shipped to the ECA server via api/request! or api/notify!.
+   `kind` is `:request` or `:notify`."
+  [bridge]
+  @(:sent-to-server bridge))
+
+(defn last-to-server-of
+  "Most recent `[kind method body]` matching method `method`, or nil."
+  [bridge method]
+  (->> @(:sent-to-server bridge) (filter #(= method (nth % 1))) last))
+
+(defn stub-reply!
+  "Pre-stage the value `api/request!` should deliver when production
+   code calls it with method `method`. Method matches the keyword
+   passed to api/request! (e.g. `:chat/prompt`)."
+  [bridge method value]
+  (swap! (:request-replies bridge) assoc method value))
+
+(defn make-stub-promise
+  "Public so macro expansion at call sites in other namespaces can
+   resolve the symbol; not intended as a general-purpose helper."
+  [value]
+  (doto (promise) (deliver value)))
+
+(defmacro with-stub-bridge
+  "Run `body` with every IO seam in webview.clj redirected through
+   `bridge-sym`:
+
+     - `webview/send-msg!`              → capture msg into bridge
+     - `webview/current-selected-editor`→ nil (no editor active)
+     - `api/connected-client`           → ::stub-client sentinel
+     - `api/request!`                   → record + deliver pre-staged
+                                          reply (defaults to {})
+     - `api/notify!`                    → record (no return)
+     - `app-manager/invoke-later!`      → run :invoke-fn synchronously
+     - `app-manager/read-action!`       → run :run-fn synchronously
+
+   The bridge is created if you do not supply one."
+  [bridge-sym & body]
+  `(let [~bridge-sym (bridge-stub)]
+     (with-redefs
+       [webview/send-msg! (fn [_project# msg#]
+                            (swap! (:sent-to-webview ~bridge-sym) conj msg#))
+        webview/current-selected-editor (constantly nil)
+        api/connected-client (constantly ::stub-client)
+        api/request! (fn [_client# args#]
+                       (let [method# (first args#)
+                             body# (second args#)]
+                         (swap! (:sent-to-server ~bridge-sym)
+                                conj [:request method# body#])
+                         (let [replies# @(:request-replies ~bridge-sym)
+                               v# (if (contains? replies# method#)
+                                    (get replies# method#)
+                                    {})]
+                           (make-stub-promise v#))))
+        api/notify! (fn [_client# args#]
+                      (let [method# (first args#)
+                            body# (second args#)]
+                        (swap! (:sent-to-server ~bridge-sym)
+                               conj [:notify method# body#]))
+                      nil)
+        app-manager/invoke-later! (fn [opts#] ((:invoke-fn opts#)))
+        app-manager/read-action! (fn [opts#] ((:run-fn opts#)))]
+       ~@body)))
+
+;; ── Misc helpers ──────────────────────────────────────────────────
+
+(defn msg->json
+  "Serialize a captured outbound message through the same path
+   send-msg! takes in production (kebab→camel keys, then cheshire).
+   Useful when a test wants to assert on the literal JSON shape."
+  [msg]
+  (json/generate-string (shared/map->camel-cased-map msg)))
+
+(defn to-json-payload
+  "Webview → host messages arrive as JSON strings. Build one from a
+   Clojure map so tests can drive `webview/handle` with realistic input."
+  [m]
+  (json/generate-string m))

--- a/src/test/clojure/dev/eca/eca_intellij/webview_chat_test.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/webview_chat_test.clj
@@ -1,15 +1,12 @@
 (ns dev.eca.eca-intellij.webview-chat-test
-  "Integration tests for the chat/* branches of `webview/handle` and
-   the server-side multimethods that forward chat notifications back to
-   the webview. Every recent chat-related regression has a named test
-   pinned to its commit hash."
+  "Tests for the chat/* branches of webview/handle and the server-side
+   multimethods that forward chat notifications back to the webview.
+   Recent regressions have a named test pinned to their commit hash."
   (:require
    [clojure.test :refer [deftest is testing]]
    [dev.eca.eca-intellij.api :as api]
    [dev.eca.eca-intellij.test-fixtures :as fixt]
    [dev.eca.eca-intellij.webview :as webview]))
-
-;; ── chat/userPrompt → chat/newChat ────────────────────────────────
 
 (deftest user-prompt-forwards-to-server-with-full-body
   (fixt/with-test-project [project]
@@ -50,10 +47,6 @@
         (is (some? reply))
         (is (= "fresh-chat-id" (get-in reply [:data :id])))))))
 
-;; ── chat/selectedModelChanged / chat/selectedAgentChanged ─────────
-;; Regression: a7221cb — chatId MUST be on the outbound payload or the
-;; per-chat scope leaks across windows.
-
 (deftest selected-model-changed-carries-chat-id
   (testing "Regression a7221cb"
     (fixt/with-test-project [project]
@@ -88,8 +81,6 @@
           (is (= "chat-9" (:chatId body)))
           (is (= "code-reviewer" (:agent body))))))))
 
-;; ── chat/contentReceived forwarding ───────────────────────────────
-
 (deftest chat-content-received-forwards-verbatim-to-webview
   (testing "Server emits per-token streaming via chat/contentReceived;
             the host MUST forward verbatim (no aggregation) so the
@@ -115,9 +106,7 @@
         (is (= ["tok-0" "tok-1" "tok-2" "tok-3" "tok-4"]
                (mapv #(get-in % [:data :content]) msgs))
             "ordering relies on lsp4clj pipeline-blocking parallelism=1
-             — verify the host forward path itself does not reorder")))))
-
-;; ── chat/queryContext / queryCommands / queryFiles ────────────────
+             -- verify the host forward path itself does not reorder")))))
 
 (deftest query-context-round-trips-result
   (fixt/with-test-project [project]
@@ -161,8 +150,6 @@
         project)
       (let [reply (fixt/last-to-webview-of-type bridge "chat/queryFiles")]
         (is (= ["/a/b.clj" "/c/d.clj"] (get-in reply [:data :files])))))))
-
-;; ── chat/{toolCallApprove,toolCallReject,promptStop,promptSteer,…} ─
 
 (deftest tool-call-approve-routes-to-server-as-notify
   (fixt/with-test-project [project]
@@ -249,8 +236,6 @@
         project)
       (is (= :request (first (fixt/last-to-server-of bridge :chat/removeFlag)))))))
 
-;; ── chat-cleared / chat-deleted / chat-opened / chat-status-changed ──
-
 (deftest chat-cleared-forwarded-to-webview
   (fixt/with-test-project [project]
     (fixt/with-stub-bridge bridge
@@ -259,7 +244,7 @@
         (is (= "c1" (get-in reply [:data :chatId])))))))
 
 (deftest chat-deleted-forwards-only-the-chat-id
-  (testing "Production code extracts :chatId — verify the wire payload
+  (testing "Production code extracts :chatId -- verify the wire payload
             is the bare id, not the full params map."
     (fixt/with-test-project [project]
       (fixt/with-stub-bridge bridge
@@ -282,8 +267,6 @@
                                {:chatId "c1" :status "streaming"})
       (let [reply (fixt/last-to-webview-of-type bridge "chat/statusChanged")]
         (is (= "streaming" (get-in reply [:data :status])))))))
-
-;; ── chat/askQuestion request/reply correlation ───────────────────
 
 (deftest ask-question-registers-pending-promise-and-resolves-on-answer
   (testing "Server invokes our `chat/askQuestion` request handler,
@@ -321,14 +304,19 @@
 
 (deftest ask-question-ignores-unknown-request-id
   (testing "answerQuestion with a requestId that was never minted must
-            not throw — the React app can race the host on focus
-            changes (we'd rather drop than crash)."
+            not throw and must not emit any host-side side effect (no
+            outbound to server, no outbound to webview)."
     (fixt/with-test-project [project]
       (fixt/with-stub-bridge bridge
-        (is (nil?
-             (webview/handle
-              (fixt/to-json-payload {:type "chat/answerQuestion"
-                                     :data {:requestId "bogus"
-                                            :answer "y"}})
-              project))
-            "unknown id is a no-op, return value matches the rest of handle")))))
+        (let [pending @@#'webview/pending-questions]
+          (webview/handle
+           (fixt/to-json-payload {:type "chat/answerQuestion"
+                                  :data {:requestId "bogus"
+                                         :answer "y"}})
+           project)
+          (is (= pending @@#'webview/pending-questions)
+              "pending-questions atom must not be mutated for unknown ids")
+          (is (empty? (fixt/sent-to-server bridge))
+              "no server-bound request or notify")
+          (is (empty? (fixt/sent-to-webview bridge))
+              "no webview-bound message"))))))

--- a/src/test/clojure/dev/eca/eca_intellij/webview_chat_test.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/webview_chat_test.clj
@@ -1,0 +1,334 @@
+(ns dev.eca.eca-intellij.webview-chat-test
+  "Integration tests for the chat/* branches of `webview/handle` and
+   the server-side multimethods that forward chat notifications back to
+   the webview. Every recent chat-related regression has a named test
+   pinned to its commit hash."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [dev.eca.eca-intellij.api :as api]
+   [dev.eca.eca-intellij.test-fixtures :as fixt]
+   [dev.eca.eca-intellij.webview :as webview]))
+
+;; ── chat/userPrompt → chat/newChat ────────────────────────────────
+
+(deftest user-prompt-forwards-to-server-with-full-body
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (fixt/stub-reply! bridge :chat/prompt {:chat-id "new-chat-1"})
+      (webview/handle
+        (fixt/to-json-payload
+          {:type "chat/userPrompt"
+           :data {:chatId "old-chat"
+                  :prompt "what is 2+2"
+                  :model "claude"
+                  :variant "sonnet"
+                  :trust "ask"
+                  :agent "researcher"
+                  :requestId "req-1"
+                  :contexts [{:type "file" :path "/a"}]}})
+        project)
+      (let [[kind method body] (fixt/last-to-server-of bridge :chat/prompt)]
+        (is (= :request kind))
+        (is (= "old-chat" (:chatId body)))
+        (is (= "what is 2+2" (:message body)))
+        (is (= "claude" (:model body)))
+        (is (= "sonnet" (:variant body)))
+        (is (= "ask" (:trust body)))
+        (is (= "researcher" (:agent body)))
+        (is (= "req-1" (:requestId body)))
+        (is (= [{:type "file" :path "/a"}] (:contexts body)))))))
+
+(deftest user-prompt-emits-new-chat-with-id-from-server-result
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (fixt/stub-reply! bridge :chat/prompt {:chat-id "fresh-chat-id"})
+      (webview/handle
+        (fixt/to-json-payload {:type "chat/userPrompt"
+                               :data {:prompt "hi"}})
+        project)
+      (let [reply (fixt/last-to-webview-of-type bridge "chat/newChat")]
+        (is (some? reply))
+        (is (= "fresh-chat-id" (get-in reply [:data :id])))))))
+
+;; ── chat/selectedModelChanged / chat/selectedAgentChanged ─────────
+;; Regression: a7221cb — chatId MUST be on the outbound payload or the
+;; per-chat scope leaks across windows.
+
+(deftest selected-model-changed-carries-chat-id
+  (testing "Regression a7221cb"
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (webview/handle
+          (fixt/to-json-payload {:type "chat/selectedModelChanged"
+                                 :data {:chatId "chat-7"
+                                        :model "claude"
+                                        :variant "sonnet"}})
+          project)
+        (let [[kind method body] (fixt/last-to-server-of
+                                  bridge :chat/selectedModelChanged)]
+          (is (= :notify kind))
+          (is (= "chat-7" (:chatId body))
+              "chatId MUST be present on selectedModelChanged or the
+               cached :server-config replay leaks across chats")
+          (is (= "claude" (:model body)))
+          (is (= "sonnet" (:variant body))))))))
+
+(deftest selected-agent-changed-carries-chat-id
+  (testing "Regression a7221cb"
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (webview/handle
+          (fixt/to-json-payload {:type "chat/selectedAgentChanged"
+                                 :data {:chatId "chat-9"
+                                        :agent "code-reviewer"}})
+          project)
+        (let [[kind _method body] (fixt/last-to-server-of
+                                   bridge :chat/selectedAgentChanged)]
+          (is (= :notify kind))
+          (is (= "chat-9" (:chatId body)))
+          (is (= "code-reviewer" (:agent body))))))))
+
+;; ── chat/contentReceived forwarding ───────────────────────────────
+
+(deftest chat-content-received-forwards-verbatim-to-webview
+  (testing "Server emits per-token streaming via chat/contentReceived;
+            the host MUST forward verbatim (no aggregation) so the
+            React app renders one token at a time."
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (api/chat-content-received {:project project}
+                                   {:chatId "c1" :content "hello"})
+        (api/chat-content-received {:project project}
+                                   {:chatId "c1" :content " world"})
+        (let [msgs (fixt/webview-of-type bridge "chat/contentReceived")]
+          (is (= 2 (count msgs)))
+          (is (= "hello" (get-in (first msgs) [:data :content])))
+          (is (= " world" (get-in (second msgs) [:data :content]))))))))
+
+(deftest chat-content-received-preserves-server-emission-order
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (doseq [i (range 5)]
+        (api/chat-content-received {:project project}
+                                   {:chatId "c1" :content (str "tok-" i)}))
+      (let [msgs (fixt/webview-of-type bridge "chat/contentReceived")]
+        (is (= ["tok-0" "tok-1" "tok-2" "tok-3" "tok-4"]
+               (mapv #(get-in % [:data :content]) msgs))
+            "ordering relies on lsp4clj pipeline-blocking parallelism=1
+             — verify the host forward path itself does not reorder")))))
+
+;; ── chat/queryContext / queryCommands / queryFiles ────────────────
+
+(deftest query-context-round-trips-result
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (fixt/stub-reply! bridge :chat/queryContext
+                        {:items [{:label "foo.clj"}]})
+      (webview/handle
+        (fixt/to-json-payload {:type "chat/queryContext"
+                               :data {:query "fo"}})
+        project)
+      (let [reply (fixt/last-to-webview-of-type bridge "chat/queryContext")]
+        (is (= [{:label "foo.clj"}] (get-in reply [:data :items])))))))
+
+(deftest query-commands-tolerates-missing-arguments-field
+  (testing "Regression f3c251f: ChatCommand.arguments arriving nil
+            used to crash the command picker. The host-side forward
+            must NOT reshape that nil into something that breaks the
+            React side; just pass it through unchanged."
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (fixt/stub-reply! bridge :chat/queryCommands
+                          {:items [{:name "review" :arguments nil}]})
+        (webview/handle
+          (fixt/to-json-payload {:type "chat/queryCommands"
+                                 :data {:query ""}})
+          project)
+        (let [reply (fixt/last-to-webview-of-type bridge "chat/queryCommands")
+              first-item (-> reply :data :items first)]
+          (is (= "review" (:name first-item)))
+          (is (nil? (:arguments first-item))
+              ":arguments nil must survive the forward unchanged"))))))
+
+(deftest query-files-round-trips-result
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (fixt/stub-reply! bridge :chat/queryFiles
+                        {:files ["/a/b.clj" "/c/d.clj"]})
+      (webview/handle
+        (fixt/to-json-payload {:type "chat/queryFiles"
+                               :data {:query "clj"}})
+        project)
+      (let [reply (fixt/last-to-webview-of-type bridge "chat/queryFiles")]
+        (is (= ["/a/b.clj" "/c/d.clj"] (get-in reply [:data :files])))))))
+
+;; ── chat/{toolCallApprove,toolCallReject,promptStop,promptSteer,…} ─
+
+(deftest tool-call-approve-routes-to-server-as-notify
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (webview/handle
+        (fixt/to-json-payload {:type "chat/toolCallApprove"
+                               :data {:chatId "c1" :callId "tc-1"}})
+        project)
+      (let [[kind _ body] (fixt/last-to-server-of bridge :chat/toolCallApprove)]
+        (is (= :notify kind))
+        (is (= "tc-1" (:callId body)))))))
+
+(deftest tool-call-reject-routes-to-server-as-notify
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (webview/handle
+        (fixt/to-json-payload {:type "chat/toolCallReject"
+                               :data {:chatId "c1" :callId "tc-1"}})
+        project)
+      (is (= :notify (first (fixt/last-to-server-of
+                             bridge :chat/toolCallReject)))))))
+
+(deftest prompt-stop-routes-to-server-as-notify
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (webview/handle
+        (fixt/to-json-payload {:type "chat/promptStop"
+                               :data {:chatId "c1"}})
+        project)
+      (let [[kind _ body] (fixt/last-to-server-of bridge :chat/promptStop)]
+        (is (= :notify kind))
+        (is (= "c1" (:chatId body)))))))
+
+(deftest prompt-steer-routes-to-server-as-notify
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (webview/handle
+        (fixt/to-json-payload {:type "chat/promptSteer"
+                               :data {:chatId "c1" :text "be brief"}})
+        project)
+      (is (= :notify (first (fixt/last-to-server-of bridge :chat/promptSteer)))))))
+
+(deftest chat-update-routes-to-server-as-request
+  (testing "chat/update is a request (carries the new trust flag) per
+            the chat-trust toggle wiring in webview.clj."
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (webview/handle
+          (fixt/to-json-payload {:type "chat/update"
+                                 :data {:chatId "c1"
+                                        :title "renamed"
+                                        :trust "trusted"}})
+          project)
+        (let [[kind _ body] (fixt/last-to-server-of bridge :chat/update)]
+          (is (= :request kind))
+          (is (= "c1" (:chatId body)))
+          (is (= "renamed" (:title body)))
+          (is (= "trusted" (:trust body))))))))
+
+(deftest chat-delete-routes-to-server-as-request
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (webview/handle
+        (fixt/to-json-payload {:type "chat/delete"
+                               :data {:chatId "c1"}})
+        project)
+      (is (= :request (first (fixt/last-to-server-of bridge :chat/delete)))))))
+
+(deftest chat-fork-routes-to-server-as-request
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (webview/handle
+        (fixt/to-json-payload {:type "chat/fork"
+                               :data {:chatId "c1" :messageId "m-5"}})
+        project)
+      (is (= :request (first (fixt/last-to-server-of bridge :chat/fork)))))))
+
+(deftest chat-remove-flag-routes-to-server-as-request
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (webview/handle
+        (fixt/to-json-payload {:type "chat/removeFlag"
+                               :data {:chatId "c1" :flagId "f-1"}})
+        project)
+      (is (= :request (first (fixt/last-to-server-of bridge :chat/removeFlag)))))))
+
+;; ── chat-cleared / chat-deleted / chat-opened / chat-status-changed ──
+
+(deftest chat-cleared-forwarded-to-webview
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (api/chat-cleared {:project project} {:chatId "c1"})
+      (let [reply (fixt/last-to-webview-of-type bridge "chat/cleared")]
+        (is (= "c1" (get-in reply [:data :chatId])))))))
+
+(deftest chat-deleted-forwards-only-the-chat-id
+  (testing "Production code extracts :chatId — verify the wire payload
+            is the bare id, not the full params map."
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (api/chat-deleted {:project project} {:chatId "c1" :extra "ignored"})
+        (let [reply (fixt/last-to-webview-of-type bridge "chat/deleted")]
+          (is (= "c1" (:data reply))))))))
+
+(deftest chat-opened-forwarded-to-webview
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (api/chat-opened {:project project} {:chatId "c1" :title "Welcome"})
+      (let [reply (fixt/last-to-webview-of-type bridge "chat/opened")]
+        (is (= "c1" (get-in reply [:data :chatId])))
+        (is (= "Welcome" (get-in reply [:data :title])))))))
+
+(deftest chat-status-changed-forwarded-to-webview
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (api/chat-status-changed {:project project}
+                               {:chatId "c1" :status "streaming"})
+      (let [reply (fixt/last-to-webview-of-type bridge "chat/statusChanged")]
+        (is (= "streaming" (get-in reply [:data :status])))))))
+
+;; ── chat/askQuestion request/reply correlation ───────────────────
+
+(deftest ask-question-registers-pending-promise-and-resolves-on-answer
+  (testing "Server invokes our `chat/askQuestion` request handler,
+            which:
+              1. mints a requestId
+              2. sends chat/askQuestion to the webview with the id
+              3. parks on a promise registered under that id
+            The webview answers via `chat/answerQuestion` inbound,
+            which delivers the matching promise."
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        ;; Park the ask call on a future so we can race the answer
+        ;; through `handle` without blocking the test thread.
+        (let [reply-future (future
+                             (api/chat-ask-question
+                              {:project project}
+                              {:question "ok?"}))]
+          ;; Allow the future to send the outbound chat/askQuestion
+          ;; before we observe.
+          (loop [i 0]
+            (when (and (< i 50)
+                       (empty? (fixt/webview-of-type bridge "chat/askQuestion")))
+              (Thread/sleep 10)
+              (recur (inc i))))
+          (let [sent (fixt/last-to-webview-of-type bridge "chat/askQuestion")
+                request-id (get-in sent [:data :requestId])]
+            (is (some? request-id) "outbound payload includes a freshly minted requestId")
+            ;; Now deliver the answer via the inbound dispatcher.
+            (webview/handle
+              (fixt/to-json-payload {:type "chat/answerQuestion"
+                                     :data {:requestId request-id
+                                            :answer "yes"}})
+              project)
+            (is (= {:answer "yes"} (deref reply-future 1000 :timeout)))))))))
+
+(deftest ask-question-ignores-unknown-request-id
+  (testing "answerQuestion with a requestId that was never minted must
+            not throw — the React app can race the host on focus
+            changes (we'd rather drop than crash)."
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (is (nil?
+             (webview/handle
+              (fixt/to-json-payload {:type "chat/answerQuestion"
+                                     :data {:requestId "bogus"
+                                            :answer "y"}})
+              project))
+            "unknown id is a no-op, return value matches the rest of handle")))))

--- a/src/test/clojure/dev/eca/eca_intellij/webview_editor_logs_test.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/webview_editor_logs_test.clj
@@ -1,13 +1,8 @@
 (ns dev.eca.eca-intellij.webview-editor-logs-test
-  "Integration tests for the editor/*, logs/* and chat/askQuestion
-   branches that DO NOT touch IntelliJ static services inline.
-
-   The branches that DO (`editor/openFile`, `editor/openGlobalConfig`,
-   `editor/openUrl`, `editor/refresh`, `editor/openServerLogs`,
-   `editor/saveFile`) live behind a `LocalFileSystem/getInstance` or
-   `FileEditorManager/getInstance` call that cannot be exercised
-   outside an IDE sandbox; those are covered by the L3 Kotlin
-   BasePlatformTestCase suite."
+  "Tests for the editor/* and logs/* branches of webview/handle that
+   are reachable without an IDE sandbox. The branches behind
+   `LocalFileSystem/getInstance` and `FileEditorManager/getInstance`
+   are deferred to a future BasePlatformTestCase suite."
   (:require
    [cheshire.core :as json]
    [clojure.java.io :as io]
@@ -21,10 +16,8 @@
    [java.io File]
    [java.util Base64]))
 
-;; ── editor/readGlobalConfig ───────────────────────────────────────
-
 (deftest read-global-config-replies-with-content-path-and-request-id
-  (testing "Regression 88fca15: the Settings → Global Config tab spun
+  (testing "Regression 88fca15: the Settings -> Global Config tab spun
             forever before this handler existed. The reply MUST carry
             both the absolute path (so the tab can show the file
             location) and a `request-id` (which becomes `requestId`
@@ -48,7 +41,7 @@
               (is (= (.getAbsolutePath tmp) (get-in reply [:data :path])))
               (is (true? (get-in reply [:data :exists])))
               (is (= "rg-1" (get-in parsed [:data :requestId]))
-                  "the camelCase walker MUST translate :request-id → requestId
+                  "the camelCase walker MUST translate :request-id -> requestId
                    so the React reply handler can correlate"))))
         (finally (.delete tmp))))))
 
@@ -67,8 +60,6 @@
           (is (= "rg-2" (get-in reply [:data :request-id])))
           (is (= "" (get-in reply [:data :contents])))
           (is (false? (get-in reply [:data :exists]))))))))
-
-;; ── editor/writeGlobalConfig ──────────────────────────────────────
 
 (deftest write-global-config-success-echoes-request-id
   (let [tmp (File/createTempFile "eca-wg-" ".json")]
@@ -130,12 +121,12 @@
             (is (re-find #"Invalid JSONC" (get-in reply [:data :error]))))))
       (finally (when (.exists tmp) (.delete tmp))))))
 
-;; ── editor/saveClipboardImage ─────────────────────────────────────
-
 (deftest save-clipboard-image-writes-to-tmp-and-echoes-request-id
-  (testing "Image roundtrip: 1x1 transparent PNG (smallest valid PNG)."
-    (let [;; tiny base64 sample doesn't have to be a real image; the
-          ;; handler doesn't decode/validate beyond base64.
+  (testing "The handler does not decode or validate beyond base64; any
+            opaque payload is fine as the test fixture."
+    (let [;; First four bytes of a PNG magic header; not a complete
+          ;; image, but the handler only decodes the base64 and writes
+          ;; bytes to disk.
           png-bytes (byte-array [0x89 0x50 0x4E 0x47])
           b64 (.encodeToString (Base64/getEncoder) png-bytes)]
       (fixt/with-test-project [project]
@@ -174,7 +165,7 @@
           (.delete (io/file target)))))))
 
 (deftest save-clipboard-image-bad-base64-does-not-throw
-  (testing "Handler wraps the decode in try/catch — malformed base64
+  (testing "Handler wraps the decode in try/catch -- malformed base64
             must not crash the host or take the webview down."
     (fixt/with-test-project [project]
       (fixt/with-stub-bridge bridge
@@ -186,12 +177,8 @@
                                             :requestId "img-bad"}})
               project)))))))
 
-;; ── on-focus-changed defensive nil-handling ───────────────────────
-;; Regression bb315a4: NPE when an editor without a project or without
-;; a virtual file was focused.
-
 (deftest on-focus-changed-is-noop-when-editor-has-no-project
-  (testing "Regression bb315a4 — focusing the floating diff editor or
+  (testing "Regression bb315a4 -- focusing the floating diff editor or
             scratch buffer with no Project must NOT throw."
     (fixt/with-test-project [project]
       (fixt/with-stub-bridge bridge
@@ -201,8 +188,6 @@
                      editor-without-project nil)))
           (is (empty? (fixt/webview-of-type bridge "editor/focusChanged"))
               "no editor/focusChanged frame may go out for a project-less editor"))))))
-
-;; ── logs/snapshot, logs/clear, logs/appended ─────────────────────
 
 (deftest logs-snapshot-replies-with-current-buffer
   (fixt/with-test-project [project]

--- a/src/test/clojure/dev/eca/eca_intellij/webview_editor_logs_test.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/webview_editor_logs_test.clj
@@ -1,0 +1,249 @@
+(ns dev.eca.eca-intellij.webview-editor-logs-test
+  "Integration tests for the editor/*, logs/* and chat/askQuestion
+   branches that DO NOT touch IntelliJ static services inline.
+
+   The branches that DO (`editor/openFile`, `editor/openGlobalConfig`,
+   `editor/openUrl`, `editor/refresh`, `editor/openServerLogs`,
+   `editor/saveFile`) live behind a `LocalFileSystem/getInstance` or
+   `FileEditorManager/getInstance` call that cannot be exercised
+   outside an IDE sandbox; those are covered by the L3 Kotlin
+   BasePlatformTestCase suite."
+  (:require
+   [cheshire.core :as json]
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is testing]]
+   [dev.eca.eca-intellij.editor-actions :as editor-actions]
+   [dev.eca.eca-intellij.log-store :as log-store]
+   [dev.eca.eca-intellij.test-fixtures :as fixt]
+   [dev.eca.eca-intellij.webview :as webview])
+  (:import
+   [com.intellij.openapi.editor Editor]
+   [java.io File]
+   [java.util Base64]))
+
+;; ── editor/readGlobalConfig ───────────────────────────────────────
+
+(deftest read-global-config-replies-with-content-path-and-request-id
+  (testing "Regression 88fca15: the Settings → Global Config tab spun
+            forever before this handler existed. The reply MUST carry
+            both the absolute path (so the tab can show the file
+            location) and a `request-id` (which becomes `requestId`
+            after camelCase serialization)."
+    (let [tmp (File/createTempFile "eca-rg-" ".json")]
+      (try
+        (spit tmp "{\"a\": 1}")
+        (fixt/with-test-project [project]
+          (fixt/with-stub-bridge bridge
+            (with-redefs [editor-actions/get-global-config-path (fn [] tmp)]
+              (webview/handle
+                (fixt/to-json-payload {:type "editor/readGlobalConfig"
+                                       :data {:requestId "rg-1"}})
+                project))
+            (let [reply (fixt/last-to-webview-of-type
+                         bridge "editor/readGlobalConfig")
+                  json (fixt/msg->json reply)
+                  parsed (json/parse-string json keyword)]
+              (is (= "rg-1" (get-in reply [:data :request-id])))
+              (is (= "{\"a\": 1}" (get-in reply [:data :contents])))
+              (is (= (.getAbsolutePath tmp) (get-in reply [:data :path])))
+              (is (true? (get-in reply [:data :exists])))
+              (is (= "rg-1" (get-in parsed [:data :requestId]))
+                  "the camelCase walker MUST translate :request-id → requestId
+                   so the React reply handler can correlate"))))
+        (finally (.delete tmp))))))
+
+(deftest read-global-config-when-file-missing-replies-with-exists-false
+  (let [tmp (File/createTempFile "eca-rg-missing-" ".json")]
+    (.delete tmp)
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (with-redefs [editor-actions/get-global-config-path (fn [] tmp)]
+          (webview/handle
+            (fixt/to-json-payload {:type "editor/readGlobalConfig"
+                                   :data {:requestId "rg-2"}})
+            project))
+        (let [reply (fixt/last-to-webview-of-type
+                     bridge "editor/readGlobalConfig")]
+          (is (= "rg-2" (get-in reply [:data :request-id])))
+          (is (= "" (get-in reply [:data :contents])))
+          (is (false? (get-in reply [:data :exists]))))))))
+
+;; ── editor/writeGlobalConfig ──────────────────────────────────────
+
+(deftest write-global-config-success-echoes-request-id
+  (let [tmp (File/createTempFile "eca-wg-" ".json")]
+    (.delete tmp)
+    (try
+      (fixt/with-test-project [project]
+        (fixt/with-stub-bridge bridge
+          (with-redefs [editor-actions/get-global-config-path (fn [] tmp)]
+            (webview/handle
+              (fixt/to-json-payload
+                {:type "editor/writeGlobalConfig"
+                 :data {:contents "{\"a\": 1}"
+                        :requestId "wg-1"}})
+              project))
+          (let [reply (fixt/last-to-webview-of-type
+                       bridge "editor/writeGlobalConfig")]
+            (is (= "wg-1" (get-in reply [:data :request-id])))
+            (is (true? (get-in reply [:data :ok])))
+            (is (= "{\"a\": 1}" (slurp tmp))))))
+      (finally (when (.exists tmp) (.delete tmp))))))
+
+(deftest write-global-config-rejects-payload-over-1mb
+  (let [tmp (File/createTempFile "eca-wg-big-" ".json")]
+    (.delete tmp)
+    (try
+      (fixt/with-test-project [project]
+        (fixt/with-stub-bridge bridge
+          (with-redefs [editor-actions/get-global-config-path (fn [] tmp)]
+            (webview/handle
+              (fixt/to-json-payload
+                {:type "editor/writeGlobalConfig"
+                 :data {:contents (str "\"" (apply str (repeat (* 1024 1024) "a")) "\"")
+                        :requestId "wg-too-big"}})
+              project))
+          (let [reply (fixt/last-to-webview-of-type
+                       bridge "editor/writeGlobalConfig")]
+            (is (= "wg-too-big" (get-in reply [:data :request-id])))
+            (is (false? (get-in reply [:data :ok])))
+            (is (re-find #"too large" (get-in reply [:data :error])))
+            (is (not (.exists tmp)) "file MUST stay un-written on rejection"))))
+      (finally (when (.exists tmp) (.delete tmp))))))
+
+(deftest write-global-config-rejects-invalid-jsonc
+  (let [tmp (File/createTempFile "eca-wg-bad-" ".json")]
+    (.delete tmp)
+    (try
+      (fixt/with-test-project [project]
+        (fixt/with-stub-bridge bridge
+          (with-redefs [editor-actions/get-global-config-path (fn [] tmp)]
+            (webview/handle
+              (fixt/to-json-payload
+                {:type "editor/writeGlobalConfig"
+                 :data {:contents "{ this is not json"
+                        :requestId "wg-bad"}})
+              project))
+          (let [reply (fixt/last-to-webview-of-type
+                       bridge "editor/writeGlobalConfig")]
+            (is (false? (get-in reply [:data :ok])))
+            (is (re-find #"Invalid JSONC" (get-in reply [:data :error]))))))
+      (finally (when (.exists tmp) (.delete tmp))))))
+
+;; ── editor/saveClipboardImage ─────────────────────────────────────
+
+(deftest save-clipboard-image-writes-to-tmp-and-echoes-request-id
+  (testing "Image roundtrip: 1x1 transparent PNG (smallest valid PNG)."
+    (let [;; tiny base64 sample doesn't have to be a real image; the
+          ;; handler doesn't decode/validate beyond base64.
+          png-bytes (byte-array [0x89 0x50 0x4E 0x47])
+          b64 (.encodeToString (Base64/getEncoder) png-bytes)]
+      (fixt/with-test-project [project]
+        (fixt/with-stub-bridge bridge
+          (webview/handle
+            (fixt/to-json-payload {:type "editor/saveClipboardImage"
+                                   :data {:base64Data b64
+                                          :mimeType "image/png"
+                                          :requestId "img-1"}})
+            project)
+          (let [reply (fixt/last-to-webview-of-type
+                       bridge "editor/saveClipboardImage")
+                path (get-in reply [:data :requestId])
+                target (get-in reply [:data :path])]
+            (is (= "img-1" path))
+            (is (.endsWith ^String target ".png"))
+            (is (.exists (io/file target))
+                "tmp file MUST exist after the handler returns")
+            (.delete (io/file target))))))))
+
+(deftest save-clipboard-image-defaults-to-png-on-unknown-mime
+  (let [b64 (.encodeToString (Base64/getEncoder) (.getBytes "x"))]
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (webview/handle
+          (fixt/to-json-payload {:type "editor/saveClipboardImage"
+                                 :data {:base64Data b64
+                                        :mimeType "image/totally-bogus"
+                                        :requestId "img-bogus"}})
+          project)
+        (let [reply (fixt/last-to-webview-of-type
+                     bridge "editor/saveClipboardImage")
+              target (get-in reply [:data :path])]
+          (is (.endsWith ^String target ".png")
+              "unknown MIME falls back to .png so the React side can still inline")
+          (.delete (io/file target)))))))
+
+(deftest save-clipboard-image-bad-base64-does-not-throw
+  (testing "Handler wraps the decode in try/catch — malformed base64
+            must not crash the host or take the webview down."
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (is (nil?
+             (webview/handle
+              (fixt/to-json-payload {:type "editor/saveClipboardImage"
+                                     :data {:base64Data "not!valid!base64!"
+                                            :mimeType "image/png"
+                                            :requestId "img-bad"}})
+              project)))))))
+
+;; ── on-focus-changed defensive nil-handling ───────────────────────
+;; Regression bb315a4: NPE when an editor without a project or without
+;; a virtual file was focused.
+
+(deftest on-focus-changed-is-noop-when-editor-has-no-project
+  (testing "Regression bb315a4 — focusing the floating diff editor or
+            scratch buffer with no Project must NOT throw."
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (let [editor-without-project (reify Editor
+                                       (getProject [_] nil))]
+          (is (nil? ((deref #'webview/on-focus-changed)
+                     editor-without-project nil)))
+          (is (empty? (fixt/webview-of-type bridge "editor/focusChanged"))
+              "no editor/focusChanged frame may go out for a project-less editor"))))))
+
+;; ── logs/snapshot, logs/clear, logs/appended ─────────────────────
+
+(deftest logs-snapshot-replies-with-current-buffer
+  (fixt/with-test-project [project]
+    (log-store/append! project {:source :server :text "first"})
+    (log-store/append! project {:source :server :text "second"})
+    (fixt/with-stub-bridge bridge
+      (webview/handle (fixt/to-json-payload {:type "logs/snapshot"}) project)
+      (let [reply (fixt/last-to-webview-of-type bridge "logs/snapshot")]
+        (is (= 2 (count (:data reply))))
+        (is (= ["first" "second"] (mapv :text (:data reply))))))))
+
+(deftest logs-clear-empties-buffer-without-replying
+  (fixt/with-test-project [project]
+    (log-store/append! project {:source :server :text "x"})
+    (fixt/with-stub-bridge bridge
+      (webview/handle (fixt/to-json-payload {:type "logs/clear"}) project)
+      (is (empty? (log-store/snapshot project))
+          ":log-entries MUST be empty after a logs/clear"))))
+
+(deftest webview-ready-then-log-append-forwards-as-logs-appended
+  (testing "After webview/ready hooks the :webview subscriber,
+            log_store/append! MUST push a `logs/appended` envelope to
+            the React side carrying the entry payload."
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (webview/handle (fixt/to-json-payload {:type "webview/ready"}) project)
+        (log-store/append! project {:source :server :text "live tail"})
+        (let [reply (fixt/last-to-webview-of-type bridge "logs/appended")]
+          (is (some? reply))
+          (is (= "live tail" (get-in reply [:data :text]))))))))
+
+(deftest logs-appended-keys-camel-case-on-the-wire
+  (testing "Regression target: :session-id on a LogEntry MUST land as
+            sessionId after the camelCase walker so React Logs panel
+            can correlate; assert against the JSON-on-wire form."
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (webview/handle (fixt/to-json-payload {:type "webview/ready"}) project)
+        (log-store/append! project {:source :server
+                                    :session-id "sess-A"
+                                    :text "x"})
+        (let [reply (fixt/last-to-webview-of-type bridge "logs/appended")
+              wire (fixt/msg->json reply)]
+          (is (re-find #"\"sessionId\"\s*:\s*\"sess-A\"" wire)))))))

--- a/src/test/clojure/dev/eca/eca_intellij/webview_lifecycle_test.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/webview_lifecycle_test.clj
@@ -71,7 +71,7 @@
       (webview/handle (fixt/to-json-payload {:type "webview/ready"}) project)
       (is (contains? (db/get-in project [:on-focus-changed-fns]) :webview)
           ":webview key in :on-focus-changed-fns is what cursor-editor-listener fans
-           out to; missing → no live editor-focus updates to the chat"))))
+           out to; missing -> no live editor-focus updates to the chat"))))
 
 (deftest webview-ready-subscribes-log-store-with-replace-semantics
   (testing "Re-delivery of webview/ready (e.g. tool-window re-open) must
@@ -89,8 +89,8 @@
             scoped with :chatId; replaying :server-config on
             webview/ready must NOT leak a stale chatId into a new chat
             window. The dispatch path:
-            api/config-updated → db/update-in :server-config
-            → (merge old new) but with :chatId dissoc'd."
+            api/config-updated -> db/update-in :server-config
+            -> (merge old new) but with :chatId dissoc'd."
     (fixt/with-test-project [project]
       (fixt/with-stub-bridge bridge
         (api/config-updated {:project project}

--- a/src/test/clojure/dev/eca/eca_intellij/webview_lifecycle_test.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/webview_lifecycle_test.clj
@@ -1,0 +1,120 @@
+(ns dev.eca.eca-intellij.webview-lifecycle-test
+  "Integration tests for the webview ↔ host lifecycle handshake.
+
+   The webview/ready replay and the api/config-updated :chatId-strip
+   are the two pieces most recently bitten by regressions; both have
+   named tests below."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [dev.eca.eca-intellij.api :as api]
+   [dev.eca.eca-intellij.db :as db]
+   [dev.eca.eca-intellij.test-fixtures :as fixt]
+   [dev.eca.eca-intellij.webview :as webview]))
+
+(deftest webview-ready-sets-webview-ready-flag
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (webview/handle (fixt/to-json-payload {:type "webview/ready"}) project)
+      (is (true? (db/get-in project [:webview-ready?]))
+          ":webview-ready? must flip true so the 10s watchdog stops"))))
+
+(deftest webview-ready-replays-status-running-emits-both-frames
+  (testing "When status is :running on ready, the host MUST emit
+            server/setWorkspaceFolders (so the React app rebuilds its
+            workspace tree) AND server/statusChanged (so the chat input
+            unblocks). Missing either was the 'blank webview' symptom in
+            the multi-project bug repro."
+    (fixt/with-test-project [project
+                             :initial-db {:status :running
+                                          :settings {:server-path "/x"}}]
+      (fixt/with-stub-bridge bridge
+        (webview/handle (fixt/to-json-payload {:type "webview/ready"}) project)
+        (let [types (->> (fixt/sent-to-webview bridge) (map :type) set)]
+          (is (contains? types "server/setWorkspaceFolders"))
+          (is (contains? types "server/statusChanged"))
+          (is (contains? types "config/updated"))
+          (is (= "Running"
+                 (-> (fixt/last-to-webview-of-type bridge "server/statusChanged")
+                     :data))))))))
+
+(deftest webview-ready-replays-status-stopped-emits-only-status
+  (testing "When status is :stopped the workspace-folders frame must NOT
+            be replayed (it carries the live :running URI shape only)."
+    (fixt/with-test-project [project
+                             :initial-db {:status :stopped
+                                          :settings {}}]
+      (fixt/with-stub-bridge bridge
+        (webview/handle (fixt/to-json-payload {:type "webview/ready"}) project)
+        (let [types (->> (fixt/sent-to-webview bridge) (map :type) set)]
+          (is (not (contains? types "server/setWorkspaceFolders")))
+          (is (contains? types "server/statusChanged"))
+          (is (= "Stopped"
+                 (-> (fixt/last-to-webview-of-type bridge "server/statusChanged")
+                     :data))))))))
+
+(deftest webview-ready-skips-config-updated-when-settings-empty
+  (testing "handle-config-changed short-circuits if :settings is nil.
+            The webview would otherwise receive a half-formed
+            config/updated frame and crash trying to render unknown
+            settings fields."
+    (fixt/with-test-project [project
+                             :initial-db {:status :running
+                                          :settings nil}]
+      (fixt/with-stub-bridge bridge
+        (webview/handle (fixt/to-json-payload {:type "webview/ready"}) project)
+        (let [types (->> (fixt/sent-to-webview bridge) (map :type) set)]
+          (is (not (contains? types "config/updated"))))))))
+
+(deftest webview-ready-registers-on-focus-changed-listener
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (webview/handle (fixt/to-json-payload {:type "webview/ready"}) project)
+      (is (contains? (db/get-in project [:on-focus-changed-fns]) :webview)
+          ":webview key in :on-focus-changed-fns is what cursor-editor-listener fans
+           out to; missing → no live editor-focus updates to the chat"))))
+
+(deftest webview-ready-subscribes-log-store-with-replace-semantics
+  (testing "Re-delivery of webview/ready (e.g. tool-window re-open) must
+            replace the prior :webview log subscriber, not stack a
+            second one. Stacking would double every logs/appended."
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (webview/handle (fixt/to-json-payload {:type "webview/ready"}) project)
+        (webview/handle (fixt/to-json-payload {:type "webview/ready"}) project)
+        (is (= 1 (count (db/get-in project [:log-subscribers])))
+            "exactly one :webview subscriber after two webview/ready calls")))))
+
+(deftest config-updated-strips-chat-id-from-cached-server-config
+  (testing "Regression: a7221cb. The server emits per-chat config
+            scoped with :chatId; replaying :server-config on
+            webview/ready must NOT leak a stale chatId into a new chat
+            window. The dispatch path:
+            api/config-updated → db/update-in :server-config
+            → (merge old new) but with :chatId dissoc'd."
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (api/config-updated {:project project}
+                            {:chatId "should-be-stripped"
+                             :model "claude"
+                             :trust "ask"})
+        (let [cached (db/get-in project [:server-config])]
+          (is (= "claude" (:model cached)))
+          (is (= "ask" (:trust cached)))
+          (is (not (contains? cached :chatId))
+              ":chatId MUST NOT land in cached :server-config"))))))
+
+(deftest config-updated-forwards-original-params-to-webview
+  (testing "The live forward (handle-config-changed) keeps :chatId
+            because the webview's currently-focused chat handler does
+            want to scope the immediate update."
+    (fixt/with-test-project [project
+                             :initial-db {:settings {:server-path "/x"}}]
+      (fixt/with-stub-bridge bridge
+        (api/config-updated {:project project}
+                            {:chatId "chat-1"
+                             :model "claude"})
+        (let [out (fixt/last-to-webview-of-type bridge "config/updated")]
+          (is (some? out))
+          (is (= "claude" (get-in out [:data :model])))
+          (is (= "chat-1" (get-in out [:data :chatId]))
+              "live forward to the webview MUST include :chatId"))))))

--- a/src/test/clojure/dev/eca/eca_intellij/webview_mcp_providers_jobs_test.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/webview_mcp_providers_jobs_test.clj
@@ -1,0 +1,254 @@
+(ns dev.eca.eca-intellij.webview-mcp-providers-jobs-test
+  "Integration tests for the mcp/*, providers/*, jobs/* branches of
+   `webview/handle` and the matching server-side notification
+   multimethods. These three feature families all share the same
+   `requestId`-echo correlation pattern; tests below pin that shape so
+   a future refactor cannot silently break the React app's reply
+   handlers."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [dev.eca.eca-intellij.api :as api]
+   [dev.eca.eca-intellij.db :as db]
+   [dev.eca.eca-intellij.test-fixtures :as fixt]
+   [dev.eca.eca-intellij.webview :as webview]))
+
+;; ── mcp/* notifications ───────────────────────────────────────────
+
+(deftest mcp-start-server-routes-to-server-as-notify
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (webview/handle
+        (fixt/to-json-payload {:type "mcp/startServer"
+                               :data {:name "fs"}})
+        project)
+      (let [[kind _ body] (fixt/last-to-server-of bridge :mcp/startServer)]
+        (is (= :notify kind))
+        (is (= "fs" (:name body)))))))
+
+(deftest mcp-stop-server-routes-to-server-as-notify
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (webview/handle
+        (fixt/to-json-payload {:type "mcp/stopServer"
+                               :data {:name "fs"}})
+        project)
+      (is (= :notify (first (fixt/last-to-server-of bridge :mcp/stopServer)))))))
+
+(deftest mcp-connect-server-routes-to-server-as-notify
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (webview/handle
+        (fixt/to-json-payload {:type "mcp/connectServer"
+                               :data {:name "fs"}})
+        project)
+      (is (= :notify (first (fixt/last-to-server-of bridge :mcp/connectServer)))))))
+
+(deftest mcp-logout-server-routes-to-server-as-notify
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (webview/handle
+        (fixt/to-json-payload {:type "mcp/logoutServer"
+                               :data {:name "github"}})
+        project)
+      (is (= :notify (first (fixt/last-to-server-of bridge :mcp/logoutServer)))))))
+
+(deftest mcp-disable-server-routes-to-server-as-notify
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (webview/handle
+        (fixt/to-json-payload {:type "mcp/disableServer"
+                               :data {:name "fs"}})
+        project)
+      (is (= :notify (first (fixt/last-to-server-of bridge :mcp/disableServer)))))))
+
+(deftest mcp-enable-server-routes-to-server-as-notify
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (webview/handle
+        (fixt/to-json-payload {:type "mcp/enableServer"
+                               :data {:name "fs"}})
+        project)
+      (is (= :notify (first (fixt/last-to-server-of bridge :mcp/enableServer)))))))
+
+(deftest mcp-update-server-is-request-and-echoes-request-id
+  (testing "mcp/updateServer is wrapped in a future to keep the JS-query
+            thread responsive. The reply MUST include the requestId the
+            webview sent so the React reply handler can correlate."
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (fixt/stub-reply! bridge :mcp/updateServer {:ok true :name "fs"})
+        (webview/handle
+          (fixt/to-json-payload {:type "mcp/updateServer"
+                                 :data {:name "fs" :requestId "req-42"}})
+          project)
+        ;; The branch is a future — give it a moment to ship the
+        ;; outbound message.
+        (loop [i 0]
+          (when (and (< i 50)
+                     (empty? (fixt/webview-of-type bridge "mcp/updateServer")))
+            (Thread/sleep 10)
+            (recur (inc i))))
+        (let [reply (fixt/last-to-webview-of-type bridge "mcp/updateServer")]
+          (is (= "req-42" (get-in reply [:data :requestId])))
+          (is (true? (get-in reply [:data :ok]))))))))
+
+;; ── tool/serverUpdated → tool/serversUpdated ──────────────────────
+
+(deftest tool-server-updated-merges-into-db-and-forwards-vec
+  (testing "Inbound notification updates the per-name MCP server map in
+            db.clj, then forwards the *values* (a vector of all known
+            servers) to the webview under the plural type
+            `tool/serversUpdated` — the React Tools panel renders the
+            entire roster on every push."
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (api/tool-server-updated {:project project}
+                                 {:name "fs" :status "running"})
+        (api/tool-server-updated {:project project}
+                                 {:name "github" :status "running"})
+        (let [reply (fixt/last-to-webview-of-type bridge "tool/serversUpdated")]
+          (is (= 2 (count (:data reply))))
+          (is (= #{"fs" "github"} (->> reply :data (map :name) set))))
+        (let [stored (db/get-in project [:session :mcp-servers])]
+          (is (= #{"fs" "github"} (set (keys stored)))))))))
+
+;; ── providers/* request/reply correlation ────────────────────────
+
+(deftest providers-list-echoes-request-id
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (fixt/stub-reply! bridge :providers/list {:providers ["anthropic" "openai"]})
+      (webview/handle
+        (fixt/to-json-payload {:type "providers/list"
+                               :data {:requestId "lst-1"}})
+        project)
+      (loop [i 0]
+        (when (and (< i 50)
+                   (empty? (fixt/webview-of-type bridge "providers/list")))
+          (Thread/sleep 10)
+          (recur (inc i))))
+      (let [reply (fixt/last-to-webview-of-type bridge "providers/list")]
+        (is (= "lst-1" (get-in reply [:data :requestId])))
+        (is (= ["anthropic" "openai"] (get-in reply [:data :providers])))))))
+
+(deftest providers-login-echoes-request-id
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (fixt/stub-reply! bridge :providers/login {:status "logged-in"})
+      (webview/handle
+        (fixt/to-json-payload {:type "providers/login"
+                               :data {:provider "anthropic" :requestId "lg-1"}})
+        project)
+      (loop [i 0]
+        (when (and (< i 50)
+                   (empty? (fixt/webview-of-type bridge "providers/login")))
+          (Thread/sleep 10)
+          (recur (inc i))))
+      (let [reply (fixt/last-to-webview-of-type bridge "providers/login")]
+        (is (= "lg-1" (get-in reply [:data :requestId])))))))
+
+(deftest providers-login-input-echoes-request-id
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (fixt/stub-reply! bridge :providers/loginInput {:status "ok"})
+      (webview/handle
+        (fixt/to-json-payload {:type "providers/loginInput"
+                               :data {:value "tok" :requestId "lin-1"}})
+        project)
+      (loop [i 0]
+        (when (and (< i 50)
+                   (empty? (fixt/webview-of-type bridge "providers/loginInput")))
+          (Thread/sleep 10)
+          (recur (inc i))))
+      (let [reply (fixt/last-to-webview-of-type bridge "providers/loginInput")]
+        (is (= "lin-1" (get-in reply [:data :requestId])))))))
+
+(deftest providers-logout-echoes-request-id
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (fixt/stub-reply! bridge :providers/logout {:status "ok"})
+      (webview/handle
+        (fixt/to-json-payload {:type "providers/logout"
+                               :data {:provider "anthropic" :requestId "out-1"}})
+        project)
+      (loop [i 0]
+        (when (and (< i 50)
+                   (empty? (fixt/webview-of-type bridge "providers/logout")))
+          (Thread/sleep 10)
+          (recur (inc i))))
+      (let [reply (fixt/last-to-webview-of-type bridge "providers/logout")]
+        (is (= "out-1" (get-in reply [:data :requestId])))))))
+
+(deftest providers-updated-forwarded-to-webview
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (api/providers-updated {:project project}
+                             {:providers [{:id "anthropic" :loggedIn true}]})
+      (let [reply (fixt/last-to-webview-of-type bridge "providers/updated")]
+        (is (= [{:id "anthropic" :loggedIn true}]
+               (get-in reply [:data :providers])))))))
+
+;; ── jobs/* request/reply correlation ──────────────────────────────
+
+(deftest jobs-list-echoes-request-id
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (fixt/stub-reply! bridge :jobs/list {:jobs [{:id "j-1" :status "running"}]})
+      (webview/handle
+        (fixt/to-json-payload {:type "jobs/list"
+                               :data {:requestId "jl-1"}})
+        project)
+      (loop [i 0]
+        (when (and (< i 50)
+                   (empty? (fixt/webview-of-type bridge "jobs/list")))
+          (Thread/sleep 10)
+          (recur (inc i))))
+      (let [reply (fixt/last-to-webview-of-type bridge "jobs/list")]
+        (is (= "jl-1" (get-in reply [:data :requestId])))
+        (is (= [{:id "j-1" :status "running"}] (get-in reply [:data :jobs])))))))
+
+(deftest jobs-read-output-translates-job-id-to-kebab-and-echoes-request-id
+  (testing "Production code converts the webview's camelCase :jobId into
+            the server-side kebab :job-id. The reply still ships back
+            under the camelCase request id."
+    (fixt/with-test-project [project]
+      (fixt/with-stub-bridge bridge
+        (fixt/stub-reply! bridge :jobs/readOutput {:output "stdout chunk"})
+        (webview/handle
+          (fixt/to-json-payload {:type "jobs/readOutput"
+                                 :data {:jobId "j-1" :requestId "jr-1"}})
+          project)
+        (loop [i 0]
+          (when (and (< i 50)
+                     (empty? (fixt/webview-of-type bridge "jobs/readOutput")))
+            (Thread/sleep 10)
+            (recur (inc i))))
+        (let [reply (fixt/last-to-webview-of-type bridge "jobs/readOutput")
+              [_kind _method body] (fixt/last-to-server-of bridge :jobs/readOutput)]
+          (is (= "jr-1" (get-in reply [:data :requestId])))
+          (is (= "stdout chunk" (get-in reply [:data :output])))
+          (is (= "j-1" (:job-id body)) ":job-id MUST be kebab on the server-facing body"))))))
+
+(deftest jobs-kill-echoes-request-id
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (fixt/stub-reply! bridge :jobs/kill {:ok true})
+      (webview/handle
+        (fixt/to-json-payload {:type "jobs/kill"
+                               :data {:jobId "j-1" :requestId "jk-1"}})
+        project)
+      (loop [i 0]
+        (when (and (< i 50)
+                   (empty? (fixt/webview-of-type bridge "jobs/kill")))
+          (Thread/sleep 10)
+          (recur (inc i))))
+      (let [reply (fixt/last-to-webview-of-type bridge "jobs/kill")]
+        (is (= "jk-1" (get-in reply [:data :requestId])))))))
+
+(deftest jobs-updated-forwarded-to-webview
+  (fixt/with-test-project [project]
+    (fixt/with-stub-bridge bridge
+      (api/jobs-updated {:project project}
+                        {:jobs [{:id "j-1" :status "exited" :exitCode 0}]})
+      (let [reply (fixt/last-to-webview-of-type bridge "jobs/updated")]
+        (is (= 1 (count (get-in reply [:data :jobs]))))))))

--- a/src/test/clojure/dev/eca/eca_intellij/webview_mcp_providers_jobs_test.clj
+++ b/src/test/clojure/dev/eca/eca_intellij/webview_mcp_providers_jobs_test.clj
@@ -1,18 +1,13 @@
 (ns dev.eca.eca-intellij.webview-mcp-providers-jobs-test
-  "Integration tests for the mcp/*, providers/*, jobs/* branches of
-   `webview/handle` and the matching server-side notification
-   multimethods. These three feature families all share the same
-   `requestId`-echo correlation pattern; tests below pin that shape so
-   a future refactor cannot silently break the React app's reply
-   handlers."
+  "Tests for the mcp/*, providers/*, jobs/* branches of webview/handle.
+   These three families share the same requestId-echo reply pattern;
+   the tests below pin it."
   (:require
    [clojure.test :refer [deftest is testing]]
    [dev.eca.eca-intellij.api :as api]
    [dev.eca.eca-intellij.db :as db]
    [dev.eca.eca-intellij.test-fixtures :as fixt]
    [dev.eca.eca-intellij.webview :as webview]))
-
-;; ── mcp/* notifications ───────────────────────────────────────────
 
 (deftest mcp-start-server-routes-to-server-as-notify
   (fixt/with-test-project [project]
@@ -81,7 +76,7 @@
           (fixt/to-json-payload {:type "mcp/updateServer"
                                  :data {:name "fs" :requestId "req-42"}})
           project)
-        ;; The branch is a future — give it a moment to ship the
+        ;; The branch is a future -- give it a moment to ship the
         ;; outbound message.
         (loop [i 0]
           (when (and (< i 50)
@@ -92,13 +87,11 @@
           (is (= "req-42" (get-in reply [:data :requestId])))
           (is (true? (get-in reply [:data :ok]))))))))
 
-;; ── tool/serverUpdated → tool/serversUpdated ──────────────────────
-
 (deftest tool-server-updated-merges-into-db-and-forwards-vec
   (testing "Inbound notification updates the per-name MCP server map in
             db.clj, then forwards the *values* (a vector of all known
             servers) to the webview under the plural type
-            `tool/serversUpdated` — the React Tools panel renders the
+            `tool/serversUpdated` -- the React Tools panel renders the
             entire roster on every push."
     (fixt/with-test-project [project]
       (fixt/with-stub-bridge bridge
@@ -111,8 +104,6 @@
           (is (= #{"fs" "github"} (->> reply :data (map :name) set))))
         (let [stored (db/get-in project [:session :mcp-servers])]
           (is (= #{"fs" "github"} (set (keys stored)))))))))
-
-;; ── providers/* request/reply correlation ────────────────────────
 
 (deftest providers-list-echoes-request-id
   (fixt/with-test-project [project]
@@ -187,8 +178,6 @@
       (let [reply (fixt/last-to-webview-of-type bridge "providers/updated")]
         (is (= [{:id "anthropic" :loggedIn true}]
                (get-in reply [:data :providers])))))))
-
-;; ── jobs/* request/reply correlation ──────────────────────────────
 
 (deftest jobs-list-echoes-request-id
   (fixt/with-test-project [project]

--- a/src/test/clojure/eca_intellij/test_runner.clj
+++ b/src/test/clojure/eca_intellij/test_runner.clj
@@ -1,0 +1,46 @@
+(ns eca-intellij.test-runner
+  "Discovers every `*_test.clj` namespace under `src/test/clojure` and runs
+   their deftests. Exits with code 1 on the first failure or error so the
+   Gradle `clojureTest` task fails loudly.
+
+   Lives outside the `dev.eca.eca-intellij` namespace tree so its filename
+   (`test_runner.clj`) cannot match the `_test.clj` discovery pattern.
+   Invoked from build.gradle.kts via `clojure.main -m eca-intellij.test-runner`."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as string]
+   [clojure.test :as t]))
+
+(def ^:private test-root "src/test/clojure")
+
+(defn ^:private file->ns-sym [^java.io.File f]
+  (let [path (.getPath f)
+        ;; Strip the test-root prefix so we end up with a relative path,
+        ;; then translate the filesystem layout into a namespace symbol
+        ;; (e.g. dev/eca/eca_intellij/foo_test.clj
+        ;;       → dev.eca.eca-intellij.foo-test).
+        idx (string/index-of path test-root)
+        rel (subs path (+ idx (count test-root) 1))]
+    (-> rel
+        (string/replace #"\.clj$" "")
+        (string/replace #"/" ".")
+        (string/replace #"_" "-")
+        symbol)))
+
+(defn ^:private discover-test-namespaces []
+  (->> (file-seq (io/file test-root))
+       (filter #(.isFile ^java.io.File %))
+       (filter #(re-find #"_test\.clj$" (.getName ^java.io.File %)))
+       (sort-by #(.getPath ^java.io.File %))
+       (mapv file->ns-sym)))
+
+(defn -main [& _]
+  (let [nss (discover-test-namespaces)]
+    (println (format "[clojureTest] discovered %d test namespace(s)" (count nss)))
+    (doseq [ns nss]
+      (println "[clojureTest] require" ns)
+      (require ns))
+    (let [{:keys [fail error]} (apply t/run-tests nss)
+          failed? (or (pos? fail) (pos? error))]
+      (shutdown-agents)
+      (System/exit (if failed? 1 0)))))

--- a/src/test/clojure/eca_intellij/test_runner.clj
+++ b/src/test/clojure/eca_intellij/test_runner.clj
@@ -18,7 +18,7 @@
         ;; Strip the test-root prefix so we end up with a relative path,
         ;; then translate the filesystem layout into a namespace symbol
         ;; (e.g. dev/eca/eca_intellij/foo_test.clj
-        ;;       → dev.eca.eca-intellij.foo-test).
+        ;;       -> dev.eca.eca-intellij.foo-test).
         idx (string/index-of path test-root)
         rel (subs path (+ idx (count test-root) 1))]
     (-> rel


### PR DESCRIPTION
## Summary

Adds 105 Clojure tests covering the webview integration boundary, plus the runner + CI workflow so PRs gate on `bb test`.

## What is tested

- **Lifecycle**: `webview/ready` replays config + status; `:chatId` stripped from cached `:server-config` (regression `a7221cb`); log-store subscriber replaced (not duplicated) on re-ready.
- **Chat**: `chat/userPrompt -> chat/newChat`; `chat/selectedModelChanged` and `chat/selectedAgentChanged` carry `chatId` (regression `a7221cb`); `chat/contentReceived` order preserved; `chat/askQuestion` promise correlation with `chat/answerQuestion`; `chat/queryCommands` tolerates `nil` arguments (regression `f3c251f`).
- **MCP, providers, jobs**: every command routed correctly; `requestId` echo on all reply-shaped messages; `tool/serversUpdated` aggregation.
- **Editor + logs**: `editor/readGlobalConfig` and `editor/writeGlobalConfig` reply shapes (regression `88fca15`); 1 MB write cap; invalid JSONC rejection; `editor/saveClipboardImage` happy + error paths; focus NPE defensive nil-handling (regression `bb315a4`); `logs/snapshot` / `logs/clear` / live `logs/appended` round-trip.
- **Server lifecycle**: `broadcast-status!` fan-out; `Windows` -> `eca.exe` download path (regression `b27d515`).
- **Pure unit**: `map->camel-cased-map`, `throttle`, `log-store` ring buffer + subscriber semantics, JSONC strip + 1 MB validate.

## Why a `clojureTest` JavaExec task

The IntelliJ Gradle plugin's `afterEvaluate` rewrites every Gradle `Test` task to use JBR (won't run on NixOS) and injects `-Djava.system.class.loader=com.intellij.util.lang.PathClassLoader`. The PathClassLoader's `URLConnection`s aren't `JarURLConnection`s, so `clojure.lang.RT.lastModified` throws a `ClassCastException` before any deftest runs. Running the suite via `JavaExec -> clojure.main -m eca-intellij.test-runner` sidesteps both issues; the stock `test` task is left disabled so a future BasePlatformTestCase suite can ride it.

## Tiny production refactor

`webview.clj` now has a private `current-selected-editor` helper wrapping the `FileEditorManager/getInstance` static call. Lets tests stub the inline static via `with-redefs` without touching the rest of the `webview/ready` branch.

## Follow-up

L3 Kotlin platform tests (`EcaSchemeHandlerFactoryTest`, tool-window smoke) deferred. Wiring a second Test task hits the same IntelliJ-plugin mutation and needs a custom Launcher-based JavaExec runner.