### PR TITLE
Fix stale paint when switching Settings tabs (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix intermittent stale paint when switching Settings tabs (#21) where the previous tab body stayed visible behind the new one. The `JBCefBrowser` was built with `setOffScreenRendering true`; CEF's OSR pipeline occasionally failed to invalidate the freed region when a large React subtree (e.g. `LogsTab`'s up-to-5000-entry buffer) was unmounted and a sibling mounted in the same commit, leaving prior pixels onscreen until the next paint event. Switched to heavyweight rendering.
+
 ## 0.26.14
 
 - Fix empty Settings → MCPs tab on tool-window reopen (#22). `webview/ready` now replays the cached MCP roster as `tool/serversUpdated`, and `on-initialized` merges into `:session` instead of clobbering it (notifications that race ahead of `initialized` no longer get wiped).

--- a/src/main/clojure/dev/eca/eca_intellij/extension/tool_window.clj
+++ b/src/main/clojure/dev/eca/eca_intellij/extension/tool_window.clj
@@ -183,7 +183,12 @@
 
 (defn ^:private create-webview ^JBCefBrowser [^Project project url]
   (let [browser (-> (JBCefBrowser/createBuilder)
-                    (.setOffScreenRendering true) ;; TODO move to config
+                    ;; Heavyweight (native) rendering. OSR (true) intermittently fails to
+                    ;; invalidate freed regions when a large React subtree is replaced in
+                    ;; one commit (e.g. switching Settings tabs while LogsTab holds
+                    ;; thousands of entries), leaving the prior tab's pixels visible
+                    ;; behind the new one until another event triggers a repaint (#21).
+                    (.setOffScreenRendering false)
                     (.build))
         ;; Per-client JS query pool size. We previously bumped this via a
         ;; global `System.setProperty "ide.browser.jcef.jsQueryPoolSize"` inside


### PR DESCRIPTION
## Summary
- `JBCefBrowser` was built with `setOffScreenRendering true`. Under OSR, CEF intermittently fails to invalidate freed regions when a large React subtree is replaced in one commit (e.g. switching out of `LogsTab` with thousands of buffered entries), leaving the previous tab's pixels visible behind the new one until another event triggers a repaint.
- OSR was set in the initial webview scaffolding (`7c0511b`) with a `TODO move to config` note and no specific need for transparency or custom compositing.
- Switched to heavyweight rendering.

Closes #21.